### PR TITLE
Transport Python: fix for filter variable

### DIFF
--- a/python_transport/wirepas_gateway/dbus/dbus_client.py
+++ b/python_transport/wirepas_gateway/dbus/dbus_client.py
@@ -208,7 +208,7 @@ class BusClient(object):
 
     def _on_data_received(self, sender, object, iface, signal, params):
         # filter out endpoint
-        if params[4] in self.ignore_ep_filter:
+        if self.ignore_ep_filter is not None and params[4] in self.ignore_ep_filter:
             self.logger.debug(
                 "Message received on ep {} filtered out".format(params[4])
             )


### PR DESCRIPTION
Filter variable was not checked in case of full_python used.
Without it, it generates an exception for each packet reception

This full_python option should be removed soon.