### PR TITLE
Python Transport: modify default log level

### DIFF
--- a/python_transport/wirepas_gateway/dbus_print_client.py
+++ b/python_transport/wirepas_gateway/dbus_print_client.py
@@ -29,7 +29,7 @@ class PrintClient(BusClient):
         data,
     ):
         """ logs incoming data from the WM network """
-        self.logger.debug(
+        self.logger.info(
             "[{}] Sink {} FROM {} TO {} on EP {} Data Size is {}".format(
                 datetime.utcfromtimestamp(int(timestamp / 1000)).strftime(
                     "%Y-%m-%d %H:%M:%S"
@@ -57,7 +57,7 @@ def main(log_name="print_client"):
     try:
         debug_level = os.environ["DEBUG_LEVEL"]
     except KeyError:
-        debug_level = "debug"
+        debug_level = "info"
 
     logger = setup_log(log_name, level=debug_level)
     obj = PrintClient()

--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -537,7 +537,7 @@ def main():
     try:
         debug_level = os.environ["DEBUG_LEVEL"]
     except KeyError:
-        debug_level = "debug"
+        debug_level = "info"
 
     logger = setup_log("transport_service", level=debug_level)
 


### PR DESCRIPTION
Debug log level is for debug purposes and must be set explicitely.
Debug level create a log every received message.
If transport is started as a systemd service, it generates
log of processing for journald and creatd big log files.