### PR TITLE
Transport: ensure gateway_id is always a string

### DIFF
--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -546,6 +546,9 @@ def _update_parameters(settings, logger):
     if settings.gateway_id is None:
         settings.gateway_id = getnode()
 
+    # Ensure gateway_id is a string as used as mqtt client_id
+    settings.gateway_id = str(settings.gateway_id)
+
     # Parse EP list that should not be published
     if settings.ignored_endpoints_filter is not None:
         try:


### PR DESCRIPTION
It must be a string because it is used as a client id for
mqtt connection.
If set from cmd line, it is already ensured but not if it comes from
yaml config file or if id is automatically generated with getNode().

Correct fix will be to parse all yaml settings with argparse too.
It will be done later.