### PR TITLE
Expose classifiers at package level

### DIFF
--- a/python_transport/wirepas_gateway/__init__.py
+++ b/python_transport/wirepas_gateway/__init__.py
@@ -16,6 +16,7 @@ from . import utils
 from .__about__ import (
     __author__,
     __author_email__,
+    __classifiers__,
     __copyright__,
     __description__,
     __license__,
@@ -25,4 +26,3 @@ from .__about__ import (
     __version__,
     __keywords__,
 )
-


### PR DESCRIPTION
While present in the __about__ the classifiers were not
being imported at the package level.

This is causing the sphynx build to fail as it is looking for this
particular variable.