### PR TITLE
Docker-entrypoint: Template and exec call

### DIFF
--- a/container/docker-entrypoint.sh
+++ b/container/docker-entrypoint.sh
@@ -44,6 +44,7 @@ then
     then
         echo "connecting to ${WM_SERVICES_HOST}"
         TARGET="wm-gw --settings ${TRANSPORT_SERVICE}/transport.yaml"
+        cat "${TRANSPORT_SERVICE}/transport.yaml"
     fi
 
     if [[ "${TARGET}" == "sink" ]]
@@ -55,7 +56,8 @@ then
     fi
 
     echo "Starting service: ${TARGET}"
-    exec "${TARGET}"
+    #shellcheck disable=SC2086
+    exec ${TARGET}
 else
     exec "$@"
 fi

--- a/container/transport.template
+++ b/container/transport.template
@@ -5,7 +5,7 @@ port: ${WM_SERVICES_MQTT_PORT:-"8883"}
 username: ${WM_SERVICES_MQTT_USER:-"mosquittouser"}
 password: ${WM_SERVICES_MQTT_PASSWORD:-"mosquittopassword"}
 tlsfile: ${WM_SERVICES_CERTIFICATE_CHAIN:-"NOTSET"}
-unsecure_authentication: false
+unsecure_authentication: ${WM_SERVICES_ALLOW_UNSECURE:-false}
 gwid: ${WM_SERVICES_GATEWAY_ID:-"$RANDOM"}
 full_python: false
 gateway_model: ${WM_SERVICES_GATEWAY_MODEL:-"lxgw"}


### PR DESCRIPTION
The quotes on the exec call were causing issues when calling the
transport service. Apparently, the command was expanded as

/home/wirepas/wm-gw (...)

instead of the expected

wm-gw (...)

The template was also missing the expansion of one parameter
which was preventing local connections to be setup correctly.