### PR TITLE
Update wirepas-messaging version to 1.2.0rc2

### DIFF
--- a/python_transport/requirements.txt
+++ b/python_transport/requirements.txt
@@ -1,5 +1,5 @@
 # wirepas
-wirepas_messaging==1.2.0rc1
+wirepas_messaging==1.2.0rc2
 
 # Wirepas Oy
 pydbus==0.6.0


### PR DESCRIPTION
Addresses lack of protobuf package  (see https://github.com/wirepas/backend-apis/pull/22)

Related to #38 