### PR TITLE
Deploy to dockerhub from travis

### DIFF
--- a/.ci/deploy-docker.sh
+++ b/.ci/deploy-docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Wirepas Oy
+# Copyright Wirepas Ltd 2019
 
 set -e
 

--- a/.ci/deploy-docker.sh
+++ b/.ci/deploy-docker.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Wirepas Oy
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+DOCKER_TAG=${TRAVIS_TAG:-"edge"}
+IS_RELEASE=${TRAVIS_TAG:-"false"}
+
+DOCKER_USERNAME=${DOCKER_USERNAME}
+DOCKER_PASSWORD=${DOCKER_PASSWORD}
+DOCKER_ORG=${DOCKER_ORG:-"wirepas"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-"gateway"}
+
+function _push
+{
+    _TAG=${1}
+
+    # push images and manifest
+    docker push wirepas/gateway-x86:"${_TAG}"
+    docker push wirepas/gateway-arm:"${_TAG}"
+    docker push wirepas/gateway:"${_TAG}"
+}
+
+function _create_manifest()
+{
+    _TAG=${1}
+
+    # creates the manifest for x86 and ARM
+    docker manifest create wirepas/gateway:"${_TAG}" \
+                           wirepas/gateway-x86:"${_TAG}" \
+                           wirepas/gateway-arm:"${_TAG}"
+
+    # sets the correct platform for rpi
+    docker manifest annotate wirepas/gateway:"${_TAG}" \
+                             wirepas/gateway-arm:"${_TAG}" \
+                             --arch arm
+}
+
+
+function _main()
+{
+    echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+
+    _create_manifest "${DOCKER_TAG}"
+    _push "${DOCKER_TAG}"
+
+    if [[ "${IS_RELEASE}" != "false" ]]
+    then
+        _create_manifest "latest"
+        _push "latest"
+    fi
+}
+
+_main "$@"

--- a/.ci/deploy-docker.sh
+++ b/.ci/deploy-docker.sh
@@ -11,6 +11,12 @@ DOCKER_PASSWORD=${DOCKER_PASSWORD}
 DOCKER_ORG=${DOCKER_ORG:-"wirepas"}
 DOCKER_IMAGE=${DOCKER_IMAGE:-"gateway"}
 
+
+function _remove_manifest()
+{
+    rm -rf ~/.docker/manifests/docker.io_wirepas_gateway*/ || true
+}
+
 function _push
 {
     _TAG=${1}
@@ -36,16 +42,25 @@ function _create_manifest()
                              --arch arm
 }
 
+function _tag_latest()
+{
+    docker tag wirepas/gateway-x86:"${_TAG}" wirepas/gateway-x86:latest
+    docker tag wirepas/gateway-arm:"${_TAG}" wirepas/gateway-arm:latest
+}
+
 
 function _main()
 {
     echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 
+    _remove_manifest
     _create_manifest "${DOCKER_TAG}"
     _push "${DOCKER_TAG}"
 
     if [[ "${IS_RELEASE}" != "false" ]]
     then
+        _remove_manifest
+        _tag_latest
         _create_manifest "latest"
         _push "latest"
     fi

--- a/.ci/releases.sh
+++ b/.ci/releases.sh
@@ -21,7 +21,7 @@ if [[ ${GH_RELEASE_PYTHON_VERSION} =~ "rc" ]]
 then
     echo "Release candidate"
     GH_RELEASE_CANDIDATE="true"
-    GH_RELEASE_DRAFT="false"
+    GH_RELEASE_DRAFT="true"
     GH_RELEASE_NAME="\"Release candidate ${GH_RELEASE_PYTHON_VERSION}\""
 
 elif [[ ${GH_RELEASE_PYTHON_VERSION} =~ "dev" ]]
@@ -32,6 +32,8 @@ then
 fi
 
 echo "version=${GH_RELEASE_PYTHON_VERSION},name=${GH_RELEASE_NAME}, body=${GH_RELEASE_BODY}, draft=${GH_RELEASE_DRAFT}, rc=${GH_RELEASE_CANDIDATE}"
+
+github_changelog_generator -t "${GH_TOKEN}"
 
 cd "${ROOT_DIR}"
 env | grep "GH_" > releases.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ script:
   - ./.ci/test-template-generation.sh
   - ./.ci/releases.sh
   - source releases.env
-  - echo ${BUILD_TAG}
 
 deploy:
 - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,23 +13,21 @@ before_install:
   - pip3 install pipenv
   - sudo ./.ci/install-repo.sh
   - ./.ci/install-devtools.sh
-
-install:
   - pip3 install -r dev-requirements.txt
   - pip3 install -r python_transport/docs/requirements.txt
   - ./.ci/style-check.sh
-
-script:
   - ./.ci/build.sh
   - ./.ci/build-images.sh
   - ./.ci/fetch-artifacts.sh
-  - .ci/test-template-generation.sh
+
+install:
   - pip3 install ./dist/${PYTHON_PKG_NAME}*linux_x86_64.whl
+
+script:
+  - ./.ci/test-template-generation.sh
   - ./.ci/releases.sh
   - source releases.env
-
-before_deploy:
-  - github_changelog_generator -t "${GH_TOKEN}"
+  - echo ${BUILD_TAG}
 
 deploy:
 - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,12 @@ deploy:
     tags: true
     branch: master
 
+- provider: script
+  script: bash .ci/deploy-docker.sh
+  on:
+    tags: true
+    branch: master
+
 env:
   global:
     - PIPENV_VENV_IN_PROJECT=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ deploy:
 - provider: script
   script: bash .ci/deploy-docker.sh
   on:
-    tags: true
     branch: master
 
 env:


### PR DESCRIPTION
This change deprecates the gateway files under wirepas/dockerfiles and moves the build and push completely to Travis.

This way, the wheel file releases under GH and pushed to Travis will also be the one distributed through docker hub.