### PR TITLE
Fix logging level

### DIFF
--- a/python_transport/wirepas_gateway/utils/log_tools.py
+++ b/python_transport/wirepas_gateway/utils/log_tools.py
@@ -11,7 +11,6 @@
 """
 
 import sys
-import ast
 import logging
 
 
@@ -41,8 +40,8 @@ class LoggerHelper(object):
         )
 
         try:
-            self._logger.setLevel(ast.literal_eval("logging.{0}".format(self._level)))
-        except Exception:
+            self._logger.setLevel(getattr(logging, self._level))
+        except AttributeError:
             self._logger.setLevel(logging.DEBUG)
 
     @property
@@ -56,8 +55,8 @@ class LoggerHelper(object):
         self._level = "{0}".format(value.upper())
 
         try:
-            self._logger.setLevel(ast.literal_eval("logging.{0}".format(self._level)))
-        except Exception:
+            self._logger.setLevel(getattr(logging, self._level))
+        except AttributeError:
             self._logger.setLevel(logging.DEBUG)
 
     def format(self, name):
@@ -91,10 +90,8 @@ class LoggerHelper(object):
         # it will limit the input of this handler.
         try:
             level = "{0}".format(value.upper())
-            self._handlers["stderr"].setLevel(
-                ast.literal_eval("logging.{0}".format(level))
-            )
-        except Exception:
+            self._handlers["stderr"].setLevel(getattr(logging, level))
+        except AttributeError:
             self._handlers["stderr"].setLevel(logging.ERROR)
         self._logger.addHandler(self._handlers["stderr"])
 


### PR DESCRIPTION
The ast literal eval was returning a string and blocking the
logging level from changing.

Closes #99

