### PR TITLE
Manifest file path

### DIFF
--- a/.ci/build-images.sh
+++ b/.ci/build-images.sh
@@ -96,7 +96,9 @@ function _main
     # builds x86 and arm images based on manifest files
     if [[ ! -z ${BUILD_TAG} ]]
     then
+
         GIT_MANIFEST_BRANCH=refs/tags/gateway/${BUILD_TAG}
+
         _build "${DOCKERFILE_PATH}/stable/arm/docker-compose.yml" "arm" "--no-cache"
         _build "${DOCKERFILE_PATH}/stable/x86/docker-compose.yml" "x86" "--no-cache"
     else

--- a/.ci/fetch-artifacts.sh
+++ b/.ci/fetch-artifacts.sh
@@ -35,4 +35,5 @@ docker run \
         wirepas/gateway-arm:"${BUILD_TAG}" \
         bash -c "${COMMAND}"
 
+rm dist/wirepas_gateway*linux_x86_64.whl
 twine check dist/wirepas_gateway*

--- a/.ci/fetch-artifacts.sh
+++ b/.ci/fetch-artifacts.sh
@@ -35,5 +35,4 @@ docker run \
         wirepas/gateway-arm:"${BUILD_TAG}" \
         bash -c "${COMMAND}"
 
-rm dist/wirepas_gateway*linux_x86_64.whl
 twine check dist/wirepas_gateway*

--- a/container/stable/arm/docker-compose.yml
+++ b/container/stable/arm/docker-compose.yml
@@ -19,7 +19,7 @@ services:
                 DOCKER_BASE: wirepas/base:1.1-raspbian
                 CROSS_BUILD_START_CMD: cross-build-start
                 CROSS_BUILD_END_CMD: cross-build-end
-                GIT_MANIFEST_FILE: ${GIT_MANIFEST_FILE:-gateway.xml/stable.xml}
+                GIT_MANIFEST_FILE: ${GIT_MANIFEST_FILE:-gateway/stable.xml}
                 GIT_MANIFEST_URL: ${GIT_MANIFEST_URL:-https://github.com/wirepas/manifest.git}
                 GIT_MANIFEST_BRANCH: ${GIT_MANIFEST_BRANCH:-master}
 

--- a/container/stable/x86/docker-compose.yml
+++ b/container/stable/x86/docker-compose.yml
@@ -19,7 +19,7 @@ services:
                 DOCKER_BASE: wirepas/base:1.1-ubuntu
                 CROSS_BUILD_START_CMD: ":"
                 CROSS_BUILD_END_CMD: ":"
-                GIT_MANIFEST_FILE: ${GIT_MANIFEST_FILE:-gateway.xml/stable.xml}
+                GIT_MANIFEST_FILE: ${GIT_MANIFEST_FILE:-gateway/stable.xml}
                 GIT_MANIFEST_URL: ${GIT_MANIFEST_URL:-https://github.com/wirepas/manifest.git}
                 GIT_MANIFEST_BRANCH: ${GIT_MANIFEST_BRANCH:-master}
 


### PR DESCRIPTION
The manifest file path was incorrectly set in the stable
docker-compose files, causing the release build to fail.
