### PR TITLE
Custom TLS file within transport container

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,22 +340,8 @@ or specify which container you want to view the logs from with
 You must ensure that your custom certificate file exists inside the container
 where the transport service is running.
 
-You can achieve this by copying the certificate within a custom image or
-by mounting the file using the composition file.
-
-To create a custom image, inherit our image as a base and copy your
-file to the container path you wish, */etc/my-tls-file*, eg,
-
-```shell
-    FROM wirepas/gateway
-    COPY my-tls-file /etc/my-tls-file
-```
-
-Build the image and update the composition file to match the build name that
-you pick or use.
-
-In case you opt to mount the file within the transport service container,
-edit the docker-compose.yml file and add the following statement under the
+You can achieve this by mounting the file using the composition file. Edit
+the docker-compose.yml file and add the following statement under the
 transport service's volumes section:
 
 ```shell
@@ -364,7 +350,7 @@ transport service's volumes section:
       - /my-tls-file/:/etc/my-tls-file
 ```
 
-In both cases, please ensure that WM_SERVICES_CERTIFICATE_CHAIN matches
+The environment variable, WM_SERVICES_CERTIFICATE_CHAIN, must match
 the container path that you picked (*/etc/my-tls-file*).
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ following registries:
 -   [wirepas/gateway-x86][dockerhub_wirepas_x86]: x86 architecture registry
 -   [wirepas/gateway-arm][dockerhub_wirepas_arm]: arm architecture registry
 
-## Starting docker services
+### Starting docker services
 
 When running the gateway over docker, the composition will mount your host's
 system dbus inside each container. This is necessary to allow exchanging data
@@ -334,6 +334,38 @@ or specify which container you want to view the logs from with
 ```shell
     docker logs [container-name]
 ```
+
+### Using custom TLS certificates within the container
+
+You must ensure that your custom certificate file exists inside the container
+where the transport service is running.
+
+You can achieve this by copying the certificate within a custom image or
+by mounting the file using the composition file.
+
+To create a custom image, inherit our image as a base and copy your
+file to the container path you wish, */etc/my-tls-file*, eg,
+
+```shell
+    FROM wirepas/gateway
+    COPY my-tls-file /etc/my-tls-file
+```
+
+Build the image and update the composition file to match the build name that
+you pick or use.
+
+In case you opt to mount the file within the transport service container,
+edit the docker-compose.yml file and add the following statement under the
+transport service's volumes section:
+
+```shell
+    volumes:
+      - (...)
+      - /my-tls-file/:/etc/my-tls-file
+```
+
+In both cases, please ensure that WM_SERVICES_CERTIFICATE_CHAIN matches
+the container path that you picked (*/etc/my-tls-file*).
 
 ## Contributing
 

--- a/container/dev/docker-compose.yml
+++ b/container/dev/docker-compose.yml
@@ -59,6 +59,7 @@ services:
 
         volumes:
             - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
+            # - ./my-tls-file:/etc/my-tls-file
 
         logging:
             driver: journald

--- a/container/stable/arm/docker-compose.yml
+++ b/container/stable/arm/docker-compose.yml
@@ -58,6 +58,7 @@ services:
 
         volumes:
             - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
+            # - ./my-tls-file:/etc/my-tls-file
 
         logging:
             driver: journald

--- a/container/stable/x86/docker-compose.yml
+++ b/container/stable/x86/docker-compose.yml
@@ -57,6 +57,7 @@ services:
 
         volumes:
             - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
+            # - ./my-tls-file:/etc/my-tls-file
 
         logging:
             driver: journald


### PR DESCRIPTION
Clarify how to use a custom TLS file within
the transport service container.

Closes #113 
