### PR TITLE
Update travis distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 services:
   - docker
 
-dist: "xenial"
+dist: "bionic"
 jobs:
 
 before_install:


### PR DESCRIPTION
This commit changes the travis distro from xenial to bionic (18.04).

The reason for this change is to overcome the github changelog
installation issues that were appearing due to an outdated version
of Ruby.
