### PR TITLE
Changelog creation in Travis pipeline

### DIFF
--- a/.ci/releases.sh
+++ b/.ci/releases.sh
@@ -33,7 +33,14 @@ fi
 
 echo "version=${GH_RELEASE_PYTHON_VERSION},name=${GH_RELEASE_NAME}, body=${GH_RELEASE_BODY}, draft=${GH_RELEASE_DRAFT}, rc=${GH_RELEASE_CANDIDATE}"
 
+set +e
 github_changelog_generator -t "${GH_TOKEN}"
+if [[ $? -eq 1 ]]
+then
+    echo "failed to authenticate, fallback to git log"
+    git log -2 --pretty="%h >> %s" > CHANGELOG.md
+fi
+set -e
 
 cd "${ROOT_DIR}"
 env | grep "GH_" > releases.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
   - docker
 
 dist: "bionic"
-jobs:
 
 before_install:
   - sudo apt-get install build-essential libsystemd-dev dbus qemu-user-static
@@ -20,12 +19,12 @@ before_install:
   - ./.ci/build.sh
   - ./.ci/build-images.sh
   - ./.ci/fetch-artifacts.sh
+  - ./.ci/test-template-generation.sh
 
 install:
   - pip3 install ./dist/${PYTHON_PKG_NAME}*linux_x86_64.whl
 
 script:
-  - ./.ci/test-template-generation.sh
   - ./.ci/releases.sh
   - source releases.env
 


### PR DESCRIPTION
This PR allows the releases script will to have a fallback in case the GH authentication fails, which is bound to happen for external PRs.