### PR TITLE
Environment arguments

### DIFF
--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -159,8 +159,8 @@ class ParserHelper:
         self.file_settings.add_argument(
             "--settings",
             type=str,
-            default=os.environ.get("WM_LXGW_FILE_SETTINGS", None),
-            default=None,
+            required=False,
+            default=os.environ.get("WM_BCLI_FILE_SETTINGS", None),
             help="A yaml file with argument parameters (see help for options).",
         )
 

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -169,7 +169,7 @@ class ParserHelper:
         """ Commonly used MQTT arguments """
         self.mqtt.add_argument(
             "--mqtt_hostname",
-            default=os.environ.get("WM_GW_MQTT_HOST", None),
+            default=os.environ.get("WM_GW_MQTT_HOSTNAME", None),
             action="store",
             type=str,
             help="MQTT broker hostname.",

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -10,6 +10,7 @@
 """
 
 import argparse
+import os
 import ssl
 import sys
 import yaml

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -249,7 +249,7 @@ class ParserHelper:
             default=os.environ.get("WM_SERVICES_MQTT_CERT_REQS", ssl.PROTOCOL_TLSv1_2),
             action="store",
             type=str,
-            help=("Specifies the version of the  SSL / TLS protocol to be used."),
+            help=("Specifies the version of the SSL / TLS protocol to be used."),
         )
 
         self.mqtt.add_argument(

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -159,7 +159,7 @@ class ParserHelper:
         self.file_settings.add_argument(
             "--settings",
             type=str,
-            required=False,
+            default=os.environ.get("WM_LXGW_FILE_SETTINGS", None),
             default=None,
             help="A yaml file with argument parameters (see help for options).",
         )
@@ -168,7 +168,7 @@ class ParserHelper:
         """ Commonly used MQTT arguments """
         self.mqtt.add_argument(
             "--mqtt_hostname",
-            default=None,
+            default=os.environ.get("WM_SERVICES_MQTT_HOST", None),
             action="store",
             type=str,
             help="MQTT broker hostname.",
@@ -176,7 +176,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_username",
-            default=None,
+            default=os.environ.get("WM_SERVICES_MQTT_USERNAME", None),
             action="store",
             type=str,
             help="MQTT broker username.",
@@ -184,7 +184,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_password",
-            default=None,
+            default=os.environ.get("WM_SERVICES_MQTT_PASSWORD", None),
             action="store",
             type=str,
             help="MQTT broker password.",
@@ -192,7 +192,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_port",
-            default=8883,
+            default=os.environ.get("WM_SERVICES_MQTT_PORT", 8883),
             action="store",
             type=int,
             help="MQTT broker port.",
@@ -200,18 +200,20 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_ca_certs",
-            default=None,
+            default=os.environ.get("WM_SERVICES_MQTT_CA_CERTS", None),
             action="store",
             type=str,
             help=(
-                "A string path to the Certificate Authority certificate "
-                "files that are to be treated as trusted by this client."
+                "A string path to the Certificate "
+                "Authority certificate files that "
+                "are to be treated as trusted by "
+                "this client."
             ),
         )
 
         self.mqtt.add_argument(
             "--mqtt_certfile",
-            default=None,
+            default=os.environ.get("WM_SERVICES_MQTT_CLIENT_CRT", None),
             action="store",
             type=str,
             help=("Strings pointing to the PEM encoded client certificate."),
@@ -219,67 +221,71 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_keyfile",
-            default=None,
+            default=os.environ.get("WM_SERVICES_MQTT_CLIENT_KEY", None),
             action="store",
             type=str,
             help=(
-                "Strings pointing to the PEM encoded client private keys "
+                "Strings pointing to the PEM "
+                "encoded client private keys "
                 "respectively."
             ),
         )
 
         self.mqtt.add_argument(
             "--mqtt_cert_reqs",
-            default=ssl.CERT_REQUIRED,
+            default=os.environ.get("WM_SERVICES_MQTT_CERT_REQS", ssl.CERT_REQUIRED),
             action="store",
             type=str,
             help=(
-                "Defines the certificate requirements that the client "
+                "Defines the certificate "
+                "requirements that the client "
                 "imposes on the broker."
             ),
         )
 
         self.mqtt.add_argument(
             "--mqtt_tls_version",
-            default=ssl.PROTOCOL_TLSv1_2,
+            default=os.environ.get("WM_SERVICES_MQTT_CERT_REQS", ssl.PROTOCOL_TLSv1_2),
             action="store",
             type=str,
-            help=("Specifies the version of the SSL / TLS protocol to be used."),
+            help=("Specifies the version of the  SSL / TLS protocol to be used."),
         )
 
         self.mqtt.add_argument(
             "--mqtt_ciphers",
-            default=None,
+            default=os.environ.get("WM_SERVICES_MQTT_CLIENT_KEY", None),
             action="store",
             type=str,
             help=(
-                "A string specifying which encryption ciphers are "
-                "allowable for this connection."
+                "A string specifying which "
+                "encryption ciphers are allowable "
+                "for this connection."
             ),
         )
 
         self.mqtt.add_argument(
             "--mqtt_persist_session",
-            default=False,
+            default=os.environ.get("WM_SERVICES_MQTT_PERSIST_SESSION", False),
             action="store_true",
             help=(
-                "When False the broker will buffer session packets "
-                "between reconnection."
+                "When False the broker will buffer"
+                "session packets between "
+                "reconnection."
             ),
         )
 
         self.mqtt.add_argument(
             "--mqtt_force_unsecure",
-            default=False,
+            default=os.environ.get("WM_SERVICES_MQTT_FORCE_UNSECURE", False),
             action="store_true",
             help=("When True the broker will skip the TLS handshake."),
         )
 
         self.mqtt.add_argument(
             "--mqtt_allow_untrusted",
-            default=False,
+            default=os.environ.get("WM_SERVICES_MQTT_ALLOW_UNTRUSTED", False),
             action="store_true",
-            help=("When true the client will skip the TLS check."),
+            help=("When true the client will skip the certificate name check."),
         )
 
     @staticmethod
@@ -353,7 +359,7 @@ class ParserHelper:
     def add_gateway_config(self):
         self.gateway.add_argument(
             "--gateway_id",
-            default=None,
+            default=os.environ.get("WM_SERVICES_GATEWAY_ID", None),
             type=str,
             help=("Id of the gateway. It must be unique on same broker."),
         )
@@ -367,25 +373,35 @@ class ParserHelper:
         )
 
         self.gateway.add_argument(
-            "-gm", "--gateway_model", default=None, help=("Model name of the gateway.")
+            "-gm",
+            "--gateway_model",
+            default=os.environ.get("WM_SERVICES_GATEWAY_MODEL", None),
+            help=("Model name of the gateway."),
         )
 
         self.gateway.add_argument(
-            "-gv", "--gateway_version", default=None, help=("Version of the gateway.")
+            "-gv",
+            "--gateway_version",
+            default=os.environ.get("WM_SERVICES_GATEWAY_VERSION", None),
+            help=("Version of the gateway."),
         )
 
     def add_filtering_config(self):
         self.filtering.add_argument(
             "-iepf",
             "--ignored_endpoints_filter",
-            default=None,
+            default=os.environ.get(
+                "WM_SERVICES_GATEWAY_IGNORED_ENDPOINTS_FILTER", None
+            ),
             help=("Destination endpoints list to ignore (not published)."),
         )
 
         self.filtering.add_argument(
             "-wepf",
             "--whitened_endpoints_filter",
-            default=None,
+            default=os.environ.get(
+                "WM_SERVICES_GATEWAY_WHITENED_ENDPOINTS_FILTER", None
+            ),
             help=(
                 "Destination endpoints list to whiten "
                 "(no payload content, only size)."

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -169,7 +169,7 @@ class ParserHelper:
         """ Commonly used MQTT arguments """
         self.mqtt.add_argument(
             "--mqtt_hostname",
-            default=os.environ.get("WM_SERVICES_MQTT_HOST", None),
+            default=os.environ.get("WM_GW_MQTT_HOST", None),
             action="store",
             type=str,
             help="MQTT broker hostname.",
@@ -177,7 +177,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_username",
-            default=os.environ.get("WM_SERVICES_MQTT_USERNAME", None),
+            default=os.environ.get("WM_GW_MQTT_USERNAME", None),
             action="store",
             type=str,
             help="MQTT broker username.",
@@ -185,7 +185,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_password",
-            default=os.environ.get("WM_SERVICES_MQTT_PASSWORD", None),
+            default=os.environ.get("WM_GW_MQTT_PASSWORD", None),
             action="store",
             type=str,
             help="MQTT broker password.",
@@ -193,7 +193,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_port",
-            default=os.environ.get("WM_SERVICES_MQTT_PORT", 8883),
+            default=os.environ.get("WM_GW_MQTT_PORT", 8883),
             action="store",
             type=int,
             help="MQTT broker port.",
@@ -201,7 +201,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_ca_certs",
-            default=os.environ.get("WM_SERVICES_MQTT_CA_CERTS", None),
+            default=os.environ.get("WM_GW_MQTT_CA_CERTS", None),
             action="store",
             type=str,
             help=(
@@ -214,7 +214,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_certfile",
-            default=os.environ.get("WM_SERVICES_MQTT_CLIENT_CRT", None),
+            default=os.environ.get("WM_GW_MQTT_CLIENT_CRT", None),
             action="store",
             type=str,
             help=("Strings pointing to the PEM encoded client certificate."),
@@ -222,7 +222,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_keyfile",
-            default=os.environ.get("WM_SERVICES_MQTT_CLIENT_KEY", None),
+            default=os.environ.get("WM_GW_MQTT_CLIENT_KEY", None),
             action="store",
             type=str,
             help=(
@@ -234,7 +234,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_cert_reqs",
-            default=os.environ.get("WM_SERVICES_MQTT_CERT_REQS", ssl.CERT_REQUIRED),
+            default=os.environ.get("WM_GW_MQTT_CERT_REQS", ssl.CERT_REQUIRED),
             action="store",
             type=str,
             help=(
@@ -246,7 +246,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_tls_version",
-            default=os.environ.get("WM_SERVICES_MQTT_CERT_REQS", ssl.PROTOCOL_TLSv1_2),
+            default=os.environ.get("WM_GW_MQTT_CERT_REQS", ssl.PROTOCOL_TLSv1_2),
             action="store",
             type=str,
             help=("Specifies the version of the SSL / TLS protocol to be used."),
@@ -254,7 +254,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_ciphers",
-            default=os.environ.get("WM_SERVICES_MQTT_CLIENT_KEY", None),
+            default=os.environ.get("WM_GW_MQTT_CLIENT_KEY", None),
             action="store",
             type=str,
             help=(
@@ -266,7 +266,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_persist_session",
-            default=os.environ.get("WM_SERVICES_MQTT_PERSIST_SESSION", False),
+            default=os.environ.get("WM_GW_MQTT_PERSIST_SESSION", False),
             action="store_true",
             help=(
                 "When False the broker will buffer"
@@ -277,14 +277,14 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_force_unsecure",
-            default=os.environ.get("WM_SERVICES_MQTT_FORCE_UNSECURE", False),
+            default=os.environ.get("WM_GW_MQTT_FORCE_UNSECURE", False),
             action="store_true",
             help=("When True the broker will skip the TLS handshake."),
         )
 
         self.mqtt.add_argument(
             "--mqtt_allow_untrusted",
-            default=os.environ.get("WM_SERVICES_MQTT_ALLOW_UNTRUSTED", False),
+            default=os.environ.get("WM_GW_MQTT_ALLOW_UNTRUSTED", False),
             action="store_true",
             help=("When true the client will skip the certificate name check."),
         )

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -169,7 +169,7 @@ class ParserHelper:
         """ Commonly used MQTT arguments """
         self.mqtt.add_argument(
             "--mqtt_hostname",
-            default=os.environ.get("WM_GW_MQTT_HOSTNAME", None),
+            default=os.environ.get("WM_SERVICES_MQTT_HOSTNAME", None),
             action="store",
             type=str,
             help="MQTT broker hostname.",
@@ -177,7 +177,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_username",
-            default=os.environ.get("WM_GW_MQTT_USERNAME", None),
+            default=os.environ.get("WM_SERVICES_MQTT_USERNAME", None),
             action="store",
             type=str,
             help="MQTT broker username.",
@@ -185,7 +185,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_password",
-            default=os.environ.get("WM_GW_MQTT_PASSWORD", None),
+            default=os.environ.get("WM_SERVICES_MQTT_PASSWORD", None),
             action="store",
             type=str,
             help="MQTT broker password.",
@@ -193,7 +193,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_port",
-            default=os.environ.get("WM_GW_MQTT_PORT", 8883),
+            default=os.environ.get("WM_SERVICES_MQTT_PORT", 8883),
             action="store",
             type=int,
             help="MQTT broker port.",
@@ -201,7 +201,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_ca_certs",
-            default=os.environ.get("WM_GW_MQTT_CA_CERTS", None),
+            default=os.environ.get("WM_SERVICES_MQTT_CA_CERTS", None),
             action="store",
             type=str,
             help=(
@@ -214,7 +214,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_certfile",
-            default=os.environ.get("WM_GW_MQTT_CLIENT_CRT", None),
+            default=os.environ.get("WM_SERVICES_MQTT_CLIENT_CRT", None),
             action="store",
             type=str,
             help=("Strings pointing to the PEM encoded client certificate."),
@@ -222,7 +222,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_keyfile",
-            default=os.environ.get("WM_GW_MQTT_CLIENT_KEY", None),
+            default=os.environ.get("WM_SERVICES_MQTT_CLIENT_KEY", None),
             action="store",
             type=str,
             help=(
@@ -234,7 +234,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_cert_reqs",
-            default=os.environ.get("WM_GW_MQTT_CERT_REQS", ssl.CERT_REQUIRED),
+            default=os.environ.get("WM_SERVICES_MQTT_CERT_REQS", ssl.CERT_REQUIRED),
             action="store",
             type=str,
             help=(
@@ -246,7 +246,9 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_tls_version",
-            default=os.environ.get("WM_GW_MQTT_CERT_REQS", ssl.PROTOCOL_TLSv1_2),
+            default=os.environ.get(
+                "WM_SERVICES_MQTT_TLS_VERSION", ssl.PROTOCOL_TLSv1_2
+            ),
             action="store",
             type=str,
             help=("Specifies the version of the SSL / TLS protocol to be used."),
@@ -254,7 +256,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_ciphers",
-            default=os.environ.get("WM_GW_MQTT_CLIENT_KEY", None),
+            default=os.environ.get("WM_SERVICES_MQTT_CIPHERS", None),
             action="store",
             type=str,
             help=(
@@ -266,7 +268,7 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_persist_session",
-            default=os.environ.get("WM_GW_MQTT_PERSIST_SESSION", False),
+            default=os.environ.get("WM_SERVICES_MQTT_PERSIST_SESSION", False),
             action="store_true",
             help=(
                 "When False the broker will buffer"
@@ -277,14 +279,14 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_force_unsecure",
-            default=os.environ.get("WM_GW_MQTT_FORCE_UNSECURE", False),
+            default=os.environ.get("WM_SERVICES_MQTT_FORCE_UNSECURE", False),
             action="store_true",
             help=("When True the broker will skip the TLS handshake."),
         )
 
         self.mqtt.add_argument(
             "--mqtt_allow_untrusted",
-            default=os.environ.get("WM_GW_MQTT_ALLOW_UNTRUSTED", False),
+            default=os.environ.get("WM_SERVICES_MQTT_ALLOW_UNTRUSTED", False),
             action="store_true",
             help=("When true the client will skip the certificate name check."),
         )

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -161,7 +161,7 @@ class ParserHelper:
             "--settings",
             type=str,
             required=False,
-            default=os.environ.get("WM_BCLI_FILE_SETTINGS", None),
+            default=os.environ.get("WM_GW_FILE_SETTINGS", None),
             help="A yaml file with argument parameters (see help for options).",
         )
 
@@ -360,7 +360,7 @@ class ParserHelper:
     def add_gateway_config(self):
         self.gateway.add_argument(
             "--gateway_id",
-            default=os.environ.get("WM_SERVICES_GATEWAY_ID", None),
+            default=os.environ.get("WM_GW_ID", None),
             type=str,
             help=("Id of the gateway. It must be unique on same broker."),
         )
@@ -376,14 +376,14 @@ class ParserHelper:
         self.gateway.add_argument(
             "-gm",
             "--gateway_model",
-            default=os.environ.get("WM_SERVICES_GATEWAY_MODEL", None),
+            default=os.environ.get("WM_GW_MODEL", None),
             help=("Model name of the gateway."),
         )
 
         self.gateway.add_argument(
             "-gv",
             "--gateway_version",
-            default=os.environ.get("WM_SERVICES_GATEWAY_VERSION", None),
+            default=os.environ.get("WM_GW_VERSION", None),
             help=("Version of the gateway."),
         )
 
@@ -391,18 +391,14 @@ class ParserHelper:
         self.filtering.add_argument(
             "-iepf",
             "--ignored_endpoints_filter",
-            default=os.environ.get(
-                "WM_SERVICES_GATEWAY_IGNORED_ENDPOINTS_FILTER", None
-            ),
+            default=os.environ.get("WM_GW_IGNORED_ENDPOINTS_FILTER", None),
             help=("Destination endpoints list to ignore (not published)."),
         )
 
         self.filtering.add_argument(
             "-wepf",
             "--whitened_endpoints_filter",
-            default=os.environ.get(
-                "WM_SERVICES_GATEWAY_WHITENED_ENDPOINTS_FILTER", None
-            ),
+            default=os.environ.get("WM_GW_WHITENED_ENDPOINTS_FILTER", None),
             help=(
                 "Destination endpoints list to whiten "
                 "(no payload content, only size)."


### PR DESCRIPTION
This change allows the arguments to be sourced by the
transport service directly from the environment. 

The environment parameters follow the ones used in 
backend client and wm-config v2.0.0.

Closes #103

To decide/tweak:

- [x] set final env names