### PR TITLE
Remove local wheel build

### DIFF
--- a/.ci/requirements.sh
+++ b/.ci/requirements.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Copyright 2019 Wirepas Ltd
 
-sudo apt-get install build-essential libsystemd-dev dbus qemu-user-static
+sudo apt-get install build-essential libsystemd-dev dbus qemu-user-static libsystemd-dev
 sudo gem install github_changelog_generator
 pip3 install --upgrade twine
 pip3 install pipenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ dist: "bionic"
 before_install:
   - ./.ci/requirements.sh
   - ./.ci/style-check.sh
-  - ./.ci/build.sh
   - ./.ci/build-images.sh
   - ./.ci/service-tests.sh
   - ./.ci/fetch-artifacts.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ services:
 
 dist: "bionic"
 
+addons:
+  apt:
+    packages:
+      - docker-ce
+
 before_install:
   - ./.ci/requirements.sh
   - ./.ci/style-check.sh


### PR DESCRIPTION
This PR removes the local wheel build (outside the container) since the systemd headers were apparently failing to install.