### PR TITLE
try to reduce MQTT messages reordering after a reconnection

### DIFF
--- a/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
+++ b/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
@@ -130,6 +130,14 @@ class MQTTWrapper(Thread):
             1,
         )
 
+        if sock in r:
+            self._client.loop_read()
+
+        if sock in w:
+            self._client.loop_write()
+
+        self._client.loop_misc()
+
         # Check if we have something to publish
         if self._publish_queue in r:
             try:
@@ -157,14 +165,6 @@ class MQTTWrapper(Thread):
             except queue.Empty:
                 # No more packet to publish
                 pass
-
-        if sock in r:
-            self._client.loop_read()
-
-        if sock in w:
-            self._client.loop_write()
-
-        self._client.loop_misc()
 
     def _get_socket(self):
         sock = self._client.socket()


### PR DESCRIPTION
When the MQTT wrapper reconnect to the broker, the in-flight messages
(stored in the mqtt client queue) are processed after the new messages
coming from the wrapper queue.

This leads to a harmless reordering of messages, that some customers
want to avoid anyway.


This patch changes to the order of the MQTT messages processing, to keep
the orignal message order in this use-case.

