### PR TITLE
Sink Service: do not try to get channel_map if >= 4.0

### DIFF
--- a/python_transport/wirepas_gateway/dbus/sink_manager.py
+++ b/python_transport/wirepas_gateway/dbus/sink_manager.py
@@ -98,7 +98,7 @@ class Sink:
     def _get_param(self, dic, key, attribute):
         try:
             dic[key] = getattr(self.proxy, attribute)
-        except (GLib.Error, AttributeError):
+        except (GLib.Error, AttributeEr:
             # Exception raised when getting attribute (probably not set)
             # Discard channel_map as parameter present only for old stacks
             if key != "channel_map":


### PR DESCRIPTION
It generates an error in c-mesh-api for nothing.
No need to worry customers for it

