### PR TITLE
Mqtt max inflight: add parameter

### DIFF
--- a/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
+++ b/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
@@ -63,6 +63,11 @@ class MQTTWrapper(Thread):
                 self.logger.error("Cannot use secure authentication %s", e)
                 exit(-1)
 
+        self.logger.info(
+            "Max inflight messages set to %s", settings.mqtt_max_inflight_messages
+        )
+        self._client.max_inflight_messages_set(settings.mqtt_max_inflight_messages)
+
         self._client.username_pw_set(settings.mqtt_username, settings.mqtt_password)
         self._client.on_connect = self._on_connect
         self._client.on_publish = self._on_publish

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -344,6 +344,14 @@ class ParserHelper:
             ),
         )
 
+        self.mqtt.add_argument(
+            "--mqtt_max_inflight_messages",
+            default=os.environ.get("WM_SERVICES_MQTT_MAX_INFLIGHT_MESSAGES", 20),
+            action="store",
+            type=self.str2int,
+            help=("Max inflight messages for messages with qos > 0"),
+        )
+
     def add_buffering_settings(self):
         """ Parameters used to avoid black hole case """
         self.buffering.add_argument(


### PR DESCRIPTION
Export the mqtt max inflight messages settings to transport api
to increase the troughput in case of many messages from a gateway

Closes # .

*Brief pull request description*
