### PR TITLE
Remove log from dbus method calls

### DIFF
--- a/sink_service/com.wirepas.sink.conf
+++ b/sink_service/com.wirepas.sink.conf
@@ -18,7 +18,7 @@
 		<allow own="com.wirepas.sink.sink8"/>
 		<allow own="com.wirepas.sink.sink9"/>
 
-		<allow send_type="method_call" log="true"/>
+		<allow send_type="method_call"/>
 	</policy>
 
 </busconfig>


### PR DESCRIPTION
Remove all the traces like this:
 
Jul 22 09:27:44 raspberrypi dbus-daemon[371]: [system] Would reject message, 2 matched rules; type="method_call", sender=":1.22" (uid=1000 pid=865 comm="/usr/bin/python3 /usr/local/bin/wm-gw ") interface="org.freedesktop.DBus.Properties" member="Get" error name="(unset)" requested_reply="0" destination="com.wirepas.sink.sink1" (uid=1000 pid=344 comm="/home/pi/wirepas/sinkService -i 1 ")

from /var/log.

