### PR TITLE
Transport: Incremental event id #189

### DIFF
--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -354,7 +354,8 @@ class TransportService(BusClient):
         )
         self.logger.debug("Uplink traffic: %s | %s", topic, event.event_id)
 
-        # No need to protect data_event_id as on_data_received is always called from same thread
+        # No need to protect data_event_id as on_data_received is always
+        # called from same thread
         if self.data_event_id is not None:
             self.data_event_id += 1
 

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -391,6 +391,21 @@ class ParserHelper:
             ),
         )
 
+    def add_debug_settings(self):
+        print(os.environ.get("WM_SERVICES_DEBUG_INCR_EVENT_ID"))
+        print(bool(os.environ.get("WM_SERVICES_DEBUG_INCR_EVENT_ID")))
+        self.debug.add_argument(
+            "--debug_incr_data_event_id",
+            default=os.environ.get("WM_SERVICES_DEBUG_INCR_EVENT_ID", False),
+            type=self.str2bool,
+            nargs="?",
+            const=True,
+            help=(
+                "When true the data received event id will be incremental "
+                "starting at 0 when service starts. Otherwise it will be random 64 bits id."
+            ),
+        )
+
     @staticmethod
     def _deprecated_message(new_arg_name, deprecated_from="2.x"):
         """ Alerts the user that an argument will be deprecated within the

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -402,7 +402,8 @@ class ParserHelper:
             const=True,
             help=(
                 "When true the data received event id will be incremental "
-                "starting at 0 when service starts. Otherwise it will be random 64 bits id."
+                "starting at 0 when service starts. Otherwise it will be "
+                "random 64 bits id."
             ),
         )
 


### PR DESCRIPTION
For debug purpose, it may be needed to monitor the data
event id generated to detect missing packets.
If an expected messages is missing, it can be easily checked
if the event id is also missing (packet lost at broker level) or
if there is no hole in event id sequence then the packet is missing
earlier.

In order to enable this feature you can either use --debug_incr_data_event_id
or set environement variable WM_SERVICES_DEBUG_INCR_EVENT_ID to True or 1 or yes

Important note: only the data received event id will be incremental.
The status of gateway (online/offline) will still have a random id to
avoid disturbing the data event id.

Closes #189 
