### PR TITLE
fix a start/stop race in dbus_client

### DIFF
--- a/python_transport/wirepas_gateway/dbus/dbus_client.py
+++ b/python_transport/wirepas_gateway/dbus/dbus_client.py
@@ -6,7 +6,7 @@ import logging
 from threading import Thread
 from pydbus import SystemBus
 import dbusCExtension
-from gi.repository import GLib
+from gi.repository import GLib, GObject
 from .sink_manager import SinkManager
 
 
@@ -166,7 +166,13 @@ class BusClient:
         """
         Explicitly stop the dbus client
         """
-        self.loop.quit()
+        def stop():
+            self.loop.quit()
+            return False
+
+        # Use deffered execution to avoid start/stop races
+        GObject.timeout_add(0, stop)
+
 
     # Method should be overwritten by child class
     def on_data_received(


### PR DESCRIPTION
The self.loop.quit() behavior is not consistent with the documentation.
A following call to self.loop.run() should return but it does not.

Due to this issue, if the mqtt_wrapper get a fast connection failure
at the startup, the TransportService will stay alive without any
connection to a MQTT broker.


This patch uses the MainLoop to call quit() and avoid the race between
the calls to run() and quit()
