### PR TITLE
[RFC] add buffering monitoring support

### DIFF
--- a/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
+++ b/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
@@ -39,6 +39,7 @@ class MQTTWrapper(Thread):
         self.logger = logger
         self.on_termination_cb = on_termination_cb
         self.on_connect_cb = on_connect_cb
+        self._messages = 0
         # Set to track the unpublished packets
         self._unpublished_mid_set = set()
         # Variable to keep track of latest published packet
@@ -272,10 +273,17 @@ class MQTTWrapper(Thread):
         # Send it to the queue to be published from Mqtt thread
         self._publish_queue.put((topic, payload, qos, retain))
 
+    def _cb_counter_wrapper(self, real_cb):
+        def wrapper(*args, **kwargs):
+            self._messages = self._messages + 1
+            return real_cb(*args, **kwargs)
+
+        return wrapper
+
     def subscribe(self, topic, cb, qos=2) -> None:
         self.logger.debug("Subscribing to: {}".format(topic))
         self._client.subscribe(topic, qos)
-        self._client.message_callback_add(topic, cb)
+        self._client.message_callback_add(topic, self._cb_counter_wrapper(cb))
 
     @property
     def publish_queue_size(self):
@@ -285,6 +293,14 @@ class MQTTWrapper(Thread):
     def last_published_packet_s(self):
         delta = datetime.now() - self._timestamp_last_publish
         return delta.total_seconds()
+
+    @property
+    def published_total(self):
+        return self._publish_queue.get_total()
+
+    @property
+    def suscribed_total(self):
+        return self._messages
 
 
 class SelectableQueue(queue.Queue):
@@ -298,6 +314,8 @@ class SelectableQueue(queue.Queue):
         self._putsocket, self._getsocket = socket.socketpair()
         self._lock = Lock()
         self._size = 0
+        self._timestamp_last_publish = 0
+        self._total = 0
 
     def fileno(self):
         """
@@ -310,12 +328,17 @@ class SelectableQueue(queue.Queue):
         with self._lock:
             return self._size
 
+    def get_total(self):
+        with self._lock:
+            return self._total
+
     def put(self, item, block=True, timeout=None):
         with self._lock:
             if self._size == 0:
                 # Send 1 byte on socket to signal select
                 self._putsocket.send(b"x")
             self._size = self._size + 1
+            self._total = self._total + 1
 
             # Insert item in queue
             super().put(item, block, timeout)

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -402,6 +402,17 @@ class ParserHelper:
             ),
         )
 
+        self.buffering.add_argument(
+            "--buffering_monitor_period",
+            default=os.environ.get("WM_GW_BUFFERING_MONITOR_PERIOD", 0),
+            action="store",
+            type=self.str2int,
+            help=(
+                "Delay in seconds between two logs of the network/buffering"
+                "state (0 will disable feature)"
+            ),
+        )
+
     def add_debug_settings(self):
         self.debug.add_argument(
             "--debug_incr_data_event_id",


### PR DESCRIPTION
Here is the kind of messages that are generated:
(With blackhole detection)
Net-State: MQTT CONNECTED, MQTT messages sent 1, messages received 0
           MQTT buffers 0 (1000 max), publish delay 0 sec (10 max), sinks cost LOW
           Sink [sink1]  messages received 0, last message 0 s ago
           Sink [sink2]  messages received 0, last message 0 s ago

(Without blackhole detection)
Net-State: MQTT CONNECTED, MQTT messages sent 1, messages received 0
           MQTT buffers 0, publish delay 0 sec
           Sink [sink1]  messages received 0, last message 0 s ago
           Sink [sink2]  messages received 0, last message 0 s ago


