### PR TITLE
Fix blackhole detection

### DIFF
--- a/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
+++ b/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
@@ -41,8 +41,8 @@ class MQTTWrapper(Thread):
         self.on_connect_cb = on_connect_cb
         # Set to track the unpublished packets
         self._unpublished_mid_set = set()
-        # Variable to keep track of latest published packet
-        self._timestamp_last_publish = datetime.now()
+        # Keep track of latest published packet
+        self._publish_monitor = PublishMonitor()
 
         if settings.mqtt_use_websocket:
             transport = "websockets"
@@ -137,7 +137,7 @@ class MQTTWrapper(Thread):
 
     def _on_publish(self, client, userdata, mid):
         self._unpublished_mid_set.remove(mid)
-        self._timestamp_last_publish = datetime.now()
+        self._publish_monitor.on_publish_done()
         return
 
     def _do_select(self, sock):
@@ -280,9 +280,6 @@ class MQTTWrapper(Thread):
 
         """
         mid = self._client.publish(topic, payload, qos=qos, retain=retain).mid
-        if self.publish_queue_size == 0:
-            # Reset last published packet
-            self._timestamp_last_publish = datetime.now()
         self._unpublished_mid_set.add(mid)
 
     def publish(self, topic, payload, qos=1, retain=False) -> None:
@@ -297,6 +294,7 @@ class MQTTWrapper(Thread):
         """
         # Send it to the queue to be published from Mqtt thread
         self._publish_queue.put((topic, payload, qos, retain))
+        self._publish_monitor.on_publish_request()
 
     def subscribe(self, topic, cb, qos=2) -> None:
         self.logger.debug("Subscribing to: {}".format(topic))
@@ -305,12 +303,11 @@ class MQTTWrapper(Thread):
 
     @property
     def publish_queue_size(self):
-        return len(self._unpublished_mid_set) + self._publish_queue.get_size()
+        return self._publish_monitor.get_publish_queue_size()
 
     @property
-    def last_published_packet_s(self):
-        delta = datetime.now() - self._timestamp_last_publish
-        return delta.total_seconds()
+    def publish_waiting_time_s(self):
+        return self._publish_monitor.get_publish_waiting_time_s()
 
 
 class SelectableQueue(queue.Queue):
@@ -331,10 +328,6 @@ class SelectableQueue(queue.Queue):
         :return: the reception socket fileno
         """
         return self._getsocket.fileno()
-
-    def get_size(self):
-        with self._lock:
-            return self._size
 
     def put(self, item, block=True, timeout=None):
         with self._lock:
@@ -357,3 +350,38 @@ class SelectableQueue(queue.Queue):
                 # Consume 1 byte from socket
                 self._getsocket.recv(1)
             return item
+
+
+class PublishMonitor:
+    """
+        Object dedicated to MQTT publish monitoring, in a simple
+        and "Thread-safe" way.
+    """
+
+    def __init__(self):
+        self._lock = Lock()
+        self._size = 0
+        self._last_publish_event_timestamp = 0  # valid if size != 0
+
+    def get_publish_queue_size(self):
+        with self._lock:
+            return self._size
+
+    def get_publish_waiting_time_s(self):
+        with self._lock:
+            if self._size == 0:
+                return 0
+            else:
+                delta = datetime.now() - self._last_publish_event_timestamp
+                return delta.total_seconds()
+
+    def on_publish_request(self):
+        with self._lock:
+            if self._size == 0:
+                self._last_publish_event_timestamp = datetime.now()
+            self._size = self._size + 1
+
+    def on_publish_done(self):
+        with self._lock:
+            self._size = self._size - 1
+            self._last_publish_event_timestamp = datetime.now()

--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -90,12 +90,8 @@ class ConnectionToBackendMonitorThread(Thread):
             # No max delay set, not enabled
             return False
 
-        if self.mqtt_wrapper.publish_queue_size <= 0:
-            # No packet queued, so nothing to check
-            return False
-
         return (
-            self.mqtt_wrapper.last_published_packet_s > self.max_delay_without_publish
+            self.mqtt_wrapper.publish_waiting_time_s > self.max_delay_without_publish
         )
 
     def _is_buffer_threshold_reached(self):
@@ -123,7 +119,7 @@ class ConnectionToBackendMonitorThread(Thread):
                     self.logger.info("Increasing sink cost of all sinks")
                     self.logger.debug(
                         "Last publish: %s Queue Size %s",
-                        self.mqtt_wrapper.last_published_packet_s,
+                        self.mqtt_wrapper.publish_waiting_time_s,
                         self.mqtt_wrapper.publish_queue_size,
                     )
 


### PR DESCRIPTION
Separation of concerns leads to a simple code, easier to
understand/review.
This should fix the race issues of the blackhole detection.


For the record, this is the kind of issue we can see:
2020-03-05 09:14:49,289 | [INFO] wirepas_gateway@transport_service.py:714:Request to send data
2020-03-05 09:14:49,296 | [INFO] wirepas_gateway@transport_service.py:349:Increasing sink cost of all sinks
2020-03-05 09:14:50,327 | [INFO] wirepas_gateway@transport_service.py:362:Connection is back, decreasing sink cost of all sinks

A transient state of the mqtt_wrapper leads to a wrong blackhole detection,
and the sink cost is increased during one second.