### PR TITLE
Error code: use GW_RES_SINK_OUT_OF_MEMORY

### DIFF
--- a/python_transport/wirepas_gateway/dbus/return_code.py
+++ b/python_transport/wirepas_gateway/dbus/return_code.py
@@ -58,8 +58,7 @@ class ReturnCode:
             # APP_RES_NOT_A_SINK, Stack is not a sink
             (20, GatewayResultCode.GW_RES_INTERNAL_ERROR),
             # APP_RES_OUT_OF_MEMORY, Out of memory
-            # TODO Change error code to GW_RES_SINK_OUT_OF_MEMORY in next release
-            (21, GatewayResultCode.GW_RES_INTERNAL_ERROR),
+            (21, GatewayResultCode.GW_RES_SINK_OUT_OF_MEMORY),
             # APP_RES_INVALID_DIAG_INTERVAL, Invalid diag interval
             (22, GatewayResultCode.GW_RES_INVALID_DIAG_INTERVAL),
             # APP_RES_INVALID_SEQ,  Invalid sequence number


### PR DESCRIPTION
GW_RES_SINK_OUT_OF_MEMORY was introduced in protobuf file quite long time ago.
Because first error code was GW_RES_OK at that time it was too dangerous to take it
into use, but now we can assume that any backend are using recent enough proto files
so they have GW_RES_UNKNOWN_ERROR as first error code in list (and they know
GW_RES_SINK_OUT_OF_MEMORY)

Closes # .

*Brief pull request description*
