### PR TITLE
Gateway status

### DIFF
--- a/python_transport/tests/test_arguments.py
+++ b/python_transport/tests/test_arguments.py
@@ -18,6 +18,7 @@ env_vars["WM_SERVICES_MQTT_CIPHERS"] = "path/mqtt_ciphers"
 env_vars["WM_SERVICES_MQTT_PERSIST_SESSION"] = True
 env_vars["WM_SERVICES_MQTT_FORCE_UNSECURE"] = True
 env_vars["WM_SERVICES_MQTT_ALLOW_UNTRUSTED"] = True
+env_vars["WM_SERVICES_MQTT_RETAIN_FLAG_SUPPORTED"] = True
 
 env_vars["WM_GW_BUFFERING_MAX_BUFFERED_PACKETS"] = 1000
 env_vars["WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH"] = 128
@@ -60,11 +61,13 @@ file_vars["gateway_model"] = env_vars["WM_GW_MODEL"]
 file_vars["gateway_version"] = env_vars["WM_GW_VERSION"]
 file_vars["ignored_endpoints_filter"] = env_vars["WM_GW_IGNORED_ENDPOINTS_FILTER"]
 file_vars["whitened_endpoints_filter"] = env_vars["WM_GW_WHITENED_ENDPOINTS_FILTER"]
+file_vars["mqtt_retain_flag_supported"] = env_vars["WM_SERVICES_MQTT_RETAIN_FLAG_SUPPORTED"]
 
 booleans = [
     "WM_SERVICES_MQTT_PERSIST_SESSION",
     "WM_SERVICES_MQTT_FORCE_UNSECURE",
     "WM_SERVICES_MQTT_ALLOW_UNTRUSTED",
+    "WM_SERVICES_MQTT_RETAIN_FLAG_SUPPORTED",
 ]
 
 
@@ -139,6 +142,14 @@ def content_tests(settings, vcopy):
             vcopy["WM_SERVICES_MQTT_ALLOW_UNTRUSTED"] == settings.mqtt_allow_untrusted
         )
 
+    if "WM_SERVICES_MQTT_RETAIN_FLAG_SUPPORTED" not in vcopy:
+        assert settings.mqtt_retain_flag_supported is False
+    else:
+        assert (
+            vcopy["WM_SERVICES_MQTT_RETAIN_FLAG_SUPPORTED"]
+            == settings.mqtt_retain_flag_supported
+        )
+
     assert vcopy["WM_SERVICES_MQTT_RECONNECT_DELAY"] == settings.mqtt_reconnect_delay
     assert (
         vcopy["WM_GW_BUFFERING_MAX_BUFFERED_PACKETS"]
@@ -199,6 +210,7 @@ def test_defaults():
     assert settings.mqtt_persist_session is False
     assert settings.mqtt_force_unsecure is False
     assert settings.mqtt_allow_untrusted is False
+    assert settings.mqtt_retain_flag_supported is False
     assert settings.mqtt_reconnect_delay == 0
     assert settings.buffering_max_buffered_packets == 0
     assert settings.buffering_max_delay_without_publish == 0

--- a/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
+++ b/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
@@ -234,7 +234,7 @@ class MQTTWrapper(Thread):
 
     def _set_last_will(self, topic, data):
         # Set Last wil message
-        self._client.will_set(topic, data, qos=2, retain=True)
+        self._client.will_set(topic, data, qos=2)
 
     def run(self):
         self.running = True

--- a/python_transport/wirepas_gateway/protocol/topic_helper.py
+++ b/python_transport/wirepas_gateway/protocol/topic_helper.py
@@ -74,6 +74,10 @@ class TopicGenerator:
     def make_get_gateway_info_request_topic(gw_id):
         return TopicGenerator._make_request_topic("get_gw_info", [str(gw_id)])
 
+    @staticmethod
+    def make_get_gw_status_request_topic():
+        return TopicGenerator._make_request_topic("get_gw_status", [])
+
     ##################
     # Response Part
     ##################
@@ -124,6 +128,10 @@ class TopicGenerator:
     @staticmethod
     def make_get_gateway_info_response_topic(gw_id):
         return TopicGenerator._make_response_topic("get_gw_info", [str(gw_id)])
+
+    @staticmethod
+    def make_get_gw_status_response_topic(gw_id):
+        return TopicGenerator._make_response_topic("get_gw_status", [str(gw_id)])
 
     ##################
     # Event Part

--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -275,8 +275,6 @@ class TransportService(BusClient):
         self.mqtt_wrapper.start()
 
         self.logger.info("Gateway started with id: %s", self.gw_id)
-        self.logger.info(f"wmm version: {wmm.__version__}")
-        self.logger.info(f"mqtt_retain_flag_supported: {settings.mqtt_retain_flag_supported}")
 
         self.monitoring_thread = None
         self.minimum_sink_cost = settings.buffering_minimal_sink_cost
@@ -843,7 +841,7 @@ class TransportService(BusClient):
     ):
         # pylint: disable=unused-argument
         res = wmm.GatewayResultCode.GW_RES_OK
-        self.logger.info("Get gateway status request received")
+        self.logger.info(f"Get gateway status request received : {message.payload}")
         try:
             request = wmm.GetGatewayStatusRequest.from_payload(
                 message.payload

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -365,11 +365,22 @@ class ParserHelper:
 
         self.mqtt.add_argument(
             "--mqtt_retain_flag_supported",
-            default=os.environ.get("WM_SERVICES_MQTT_RETAIN_FLAG_SUPPORTED", False),
+            default=os.environ.get("WM_SERVICES_MQTT_RETAIN_FLAG_SUPPORTED", True),
             type=self.str2bool,
             nargs="?",
             const=True,
             help=("Set to true if broker support retain flag"),
+        )
+
+        self.mqtt.add_argument(
+            "--mqtt_max_qos_supported",
+            default=os.environ.get("WM_SERVICES_MQTT_MAX_QOS_SUPPORTED", 2),
+            action="store",
+            type=self.str2int,
+            help=(
+                "Max qos supported by broker in case it has limitation"
+                "compare to MQTT specification that is 2."
+            ),
         )
 
     def add_buffering_settings(self):

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -363,6 +363,15 @@ class ParserHelper:
             ),
         )
 
+        self.mqtt.add_argument(
+            "--mqtt_retain_flag_supported",
+            default=os.environ.get("WM_SERVICES_MQTT_RETAIN_FLAG_SUPPORTED", False),
+            type=self.str2bool,
+            nargs="?",
+            const=True,
+            help=("Set to true if broker support retain flag"),
+        )
+
     def add_buffering_settings(self):
         """ Parameters used to avoid black hole case """
         self.buffering.add_argument(


### PR DESCRIPTION
Updating the transport service to handle request on the gateway status

Adding Gateways status request and response topics.
This can be used in the case where the mqtt broker does not support retained message
and we would like to know the status of the gateways as soon as possible.

The concerned topics in the mqtt broker are :
gw-request/get_gw_status
gw-response/get_gw_status/<gw-id>/<sink-id>