### PR TITLE
Qos mqtt compatibility

### DIFF
--- a/python_transport/tests/test_arguments.py
+++ b/python_transport/tests/test_arguments.py
@@ -22,6 +22,8 @@ env_vars["WM_SERVICES_MQTT_ALLOW_UNTRUSTED"] = True
 env_vars["WM_GW_BUFFERING_MAX_BUFFERED_PACKETS"] = 1000
 env_vars["WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH"] = 128
 env_vars["WM_GW_BUFFERING_MINIMAL_SINK_COST"] = 240
+env_vars["WM_CACHE_TIME_WINDOW"] = 1800
+env_vars["WM_CACHE_UPDATE_S"] = 60
 env_vars["WM_GW_ID"] = "1"
 env_vars["WM_GW_MODEL"] = "test"
 env_vars["WM_GW_VERSION"] = "pytest"
@@ -54,6 +56,8 @@ file_vars["buffering_max_delay_without_publish"] = env_vars[
     "WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH"
 ]
 file_vars["buffering_minimal_sink_cost"] = env_vars["WM_GW_BUFFERING_MINIMAL_SINK_COST"]
+file_vars["cache_time_window"] = env_vars["WM_CACHE_TIME_WINDOW"]
+file_vars["cache_update_s"] = env_vars["WM_CACHE_UPDATE_S"]
 
 file_vars["gateway_id"] = env_vars["WM_GW_ID"]
 file_vars["gateway_model"] = env_vars["WM_GW_MODEL"]
@@ -153,6 +157,14 @@ def content_tests(settings, vcopy):
         vcopy["WM_GW_BUFFERING_MINIMAL_SINK_COST"]
         == settings.buffering_minimal_sink_cost
     )
+    assert (
+        vcopy["WM_CACHE_TIME_WINDOW"]
+        == settings.cache_time_window
+    )
+    assert (
+        vcopy["WM_CACHE_UPDATE_S"]
+        == settings.cache_update_s
+    )
 
     assert vcopy["WM_GW_ID"] == settings.gateway_id
     assert vcopy["WM_GW_MODEL"] == settings.gateway_model
@@ -202,7 +214,8 @@ def test_defaults():
     assert settings.mqtt_reconnect_delay == 0
     assert settings.buffering_max_buffered_packets == 0
     assert settings.buffering_max_delay_without_publish == 0
-    assert settings.buffering_minimal_sink_cost == 0
+    assert settings.cache_update_s == 20
+    assert settings.cache_time_window == 1200
     assert settings.gateway_id is None
     assert settings.gateway_model is None
     assert settings.gateway_version is None

--- a/python_transport/tests/test_arguments.py
+++ b/python_transport/tests/test_arguments.py
@@ -107,6 +107,7 @@ def get_args(delete_bools=False, set_env=True, set_file=False):
     parse.add_gateway_config()
     parse.add_filtering_config()
     parse.add_buffering_settings()
+    parse.add_cache_settings()
 
     settings = parse.settings()
 
@@ -196,6 +197,7 @@ def test_defaults():
     parse.add_gateway_config()
     parse.add_filtering_config()
     parse.add_buffering_settings()
+    parse.add_cache_settings()
 
     sys.argv = [sys.argv[0]]
     settings = parse.settings()
@@ -214,6 +216,7 @@ def test_defaults():
     assert settings.mqtt_reconnect_delay == 0
     assert settings.buffering_max_buffered_packets == 0
     assert settings.buffering_max_delay_without_publish == 0
+    assert settings.buffering_minimal_sink_cost == 0
     assert settings.cache_update_s == 20
     assert settings.cache_time_window == 1200
     assert settings.gateway_id is None

--- a/python_transport/tests/test_cache_message.py
+++ b/python_transport/tests/test_cache_message.py
@@ -1,0 +1,55 @@
+from time import sleep
+from wirepas_gateway.protocol.cache_message import CacheMessage
+
+CACHE_TIME_WINDOW = 0.1
+CACHE_UPDATE_S = 0.025
+REQ_ID = 160
+REQ_ID2 = 161
+
+
+def test_adding_msg():
+    """
+    Tests the adding of message in the cache.
+    """
+    cache = CacheMessage(CACHE_TIME_WINDOW, CACHE_UPDATE_S)
+    assert cache.get_size() == 0
+
+    assert cache.add_msg(REQ_ID) is True
+    assert cache.get_size() == 1
+
+    assert cache.add_msg(REQ_ID2) is True
+    assert cache.get_size() == 2
+
+    # Test the mapping in the cache
+    assert cache.is_in_cache(REQ_ID)
+    assert cache.is_in_cache(REQ_ID2)
+
+def test_duplicate():
+    """
+    Tests if the duplicate messages are not stored
+    """
+    cache = CacheMessage(CACHE_TIME_WINDOW, CACHE_UPDATE_S)
+    assert cache.get_size() == 0
+
+    assert cache.add_msg(REQ_ID) is True
+    assert cache.get_size() == 1
+    time1 = cache.msg_list[REQ_ID]
+
+    # Test if a redundant message is dropped
+    assert cache.add_msg(REQ_ID) is False
+    assert cache.get_size() == 1
+
+    # Test if the timestamp of the message has been updated
+    time2 = cache.msg_list[REQ_ID]
+    assert time1 != time2
+
+def test_cache_time_window():
+    """
+    Tests the well functionning of cache time window.
+    """
+    cache = CacheMessage(CACHE_TIME_WINDOW, CACHE_UPDATE_S)
+    assert cache.add_msg(REQ_ID) is True
+
+    # Test if the cache has reset eventually
+    sleep(CACHE_TIME_WINDOW)
+    assert cache.add_msg(REQ_ID) is True

--- a/python_transport/wirepas_gateway/protocol/cache_message.py
+++ b/python_transport/wirepas_gateway/protocol/cache_message.py
@@ -1,0 +1,76 @@
+# Copyright 2019 Wirepas Ltd licensed under Apache License, Version 2.0
+#
+# See file LICENSE for full license details.
+#
+from time import time
+from threading import Lock
+
+
+class CacheMessage:
+    """
+    Class to cache messages to avoid sending duplicates in MQTT with QoS=1.
+    """
+    def __init__(
+        self,
+        cache_time_window,
+        cache_update_s
+    ):
+        """
+        Args:
+            cache_time_window: time in seconds after which a message is clean from the cache.
+            cache_update_s: period in seconds to update the list of received messages.
+                            Must be shorter than cache_time_window
+        """
+        self._lock = Lock()
+        self.msg_list = dict()  # Dictionary of received messages id mapped to their timestamps
+
+        self.cache_time_window = cache_time_window
+        self.cache_update_s = min(cache_update_s, cache_time_window)
+
+        self.last_update_time = 0  # last time an update of the list of received messages was done
+
+    def add_msg(self, msg_id):
+        """
+        Adds a received message to the cache.
+        If the message is a duplicate, it only updates its last timestamp to the current time.
+
+        Args:
+            msg_id: the id of a message to be added to the cache.
+        """
+        current_time = time()
+        with self._lock:
+            if current_time - self.last_update_time > self.cache_update_s:
+                self._clean_msg_list()
+
+            is_duplicate = self.is_in_cache(msg_id)
+            self.msg_list[msg_id] = current_time
+            return not is_duplicate
+
+    def get_size(self):
+        """
+        Returns the number of messages in the cache.
+        """
+        with self._lock:
+            return len(self.msg_list)
+
+    def _clean_msg_list(self):
+        """
+        Clean the old messages in the cache
+        based on the time window cache_time_window attribute.
+        """
+        current_time = time()
+        self.msg_list = {
+            msg_id: msg_time for (msg_id, msg_time) in self.msg_list.items()
+            if current_time - msg_time <= self.cache_time_window
+        }
+        self.last_update_time = current_time
+
+    def is_in_cache(self, msg_id):
+        """
+        Returns True if the id of a message is already in the cache.
+        Return False otherwise.
+
+        Args:
+            msg_id: id of the message received
+        """
+        return msg_id in self.msg_list

--- a/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
+++ b/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
@@ -234,7 +234,7 @@ class MQTTWrapper(Thread):
 
     def _set_last_will(self, topic, data):
         # Set Last wil message
-        self._client.will_set(topic, data, qos=2, retain=True)
+        self._client.will_set(topic, data, qos=1, retain=True)
 
     def run(self):
         self.running = True
@@ -296,7 +296,16 @@ class MQTTWrapper(Thread):
         self._publish_queue.put((topic, payload, qos, retain))
         self._publish_monitor.on_publish_request()
 
-    def subscribe(self, topic, cb, qos=2) -> None:
+    def subscribe(self, topic, cb, qos=1) -> None:
+        """ Method to subscribe to mqtt topic
+
+        Args:
+            topic: Topic to subscribe to
+            cb: Callback to call on message reception
+            qos: Qos to use. Can be less than requested if broker does
+                 not support it
+
+        """
         self.logger.debug("Subscribing to: {}".format(topic))
         self._client.subscribe(topic, qos)
         self._client.message_callback_add(topic, cb)

--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -12,6 +12,7 @@ from threading import Thread, Lock
 from wirepas_gateway.dbus.dbus_client import BusClient
 from wirepas_gateway.protocol.topic_helper import TopicGenerator, TopicParser
 from wirepas_gateway.protocol.mqtt_wrapper import MQTTWrapper
+from wirepas_gateway.protocol.cache_message import CacheMessage
 from wirepas_gateway.utils import ParserHelper
 from wirepas_gateway.utils import LoggerHelper
 
@@ -159,83 +160,6 @@ class ConnectionToBackendMonitorThread(Thread):
                 sink.cost = self.minimum_sink_cost
 
 
-class MessageManager:
-    def __init__(
-        self,
-        time_window,
-        cache_update_s
-    ):
-        """
-        Manage and cache messages to avoid sending duplicate in MQTT with QoS=1.
-
-        Args:
-            time_window: time in seconds after which a message is clean from the cache.
-            cache_update_s: period in seconds to update the list of received messages.
-                            Must be shorter than time_window
-        """
-        self._lock = Lock()
-        self.msg_list = dict()  # Dictionary of received messages id mapped to their timestamps
-
-        self.time_window = time_window
-        self.cache_update_s = min(cache_update_s, time_window)
-
-        self.latest_timestamp = 0  # latest timestamp of a received message
-        self.last_update_time = 0  # last time an update of the list of received messages was done
-
-    def add_msg(self, msg_id):
-        """
-        Adds a received message to the cache.
-        If the message is a duplicate, it only updates its last timestamp to the current time.
-
-        Args:
-            msg_id: the id of a message to be added to the cache.
-        """
-        time_s_epoch = time()
-        with self._lock:
-            self._update_latest_timestamp(time_s_epoch)
-
-            if self.latest_timestamp - self.last_update_time >  self.cache_update_s:
-                self._update_msg_list()
-
-            is_duplicate = self._is_duplicate(msg_id)
-            self.msg_list[msg_id] = time_s_epoch
-            return not is_duplicate
-
-    def get_size(self):
-        """
-        Returns the number of messages in the cache.
-        """
-        with self._lock:
-            return len(self.msg_list)
-
-    def _update_msg_list(self):
-        """
-        Clean the old messages in the cache
-        based on cleaning time period time_window attribute.
-        """
-        self.msg_list = {
-            msg_id: msg_time for (msg_id, msg_time) in self.msg_list.items()
-            if self.latest_timestamp - msg_time <= self.time_window
-        }
-        self.last_update_time = self.latest_timestamp
-
-    def _update_latest_timestamp(self, timestamp):
-        """
-        Updates the latest timestamp of a received message.
-        """
-        self.latest_timestamp = max(self.latest_timestamp, timestamp)
-
-    def _is_duplicate(self, msg_id):
-        """
-        Returns True if the id of a message is already in the cache.
-        Return False otherwise.
-
-        Args:
-            msg_id: id of the message received
-        """
-        return msg_id in self.msg_list
-
-
 class TransportService(BusClient):
     """
     Implementation of gateway to backend protocol
@@ -311,7 +235,7 @@ class TransportService(BusClient):
         else:
             self.data_event_id = None
 
-        self.msg_manager = MessageManager(settings.cache_time_window, settings.cache_update_s)
+        self.msg_manager = CacheMessage(settings.cache_time_window, settings.cache_update_s)
 
     def _on_mqtt_wrapper_termination_cb(self):
         """

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -402,6 +402,32 @@ class ParserHelper:
             ),
         )
 
+    def add_cache_settings(self):
+        """ Parameters used to avoid sending redundant messages in the mqtt broker """
+        cleaning_time_window_default = 20*60  # 20 minutes
+        cache_update_s_default = 20  # 20 secondes
+
+        self.cache.add_argument(
+            "--cache_time_window",
+            default=os.environ.get("WM_CACHE_TIME_WINDOW", cleaning_time_window_default),
+            action="store",
+            type=self.str2int,
+            help=(
+                "Time in seconds after which a message is clean from the cache."
+            ),
+        )
+
+        self.cache.add_argument(
+            "--cache_update_s",
+            default=os.environ.get("WM_CACHE_UPDATE_S", cache_update_s_default),
+            action="store",
+            type=self.str2int,
+            help=(
+                "Period to update the list of received messages in seconds."
+                "Must be smaller than time_window"
+            ),
+        )
+
     def add_debug_settings(self):
         self.debug.add_argument(
             "--debug_incr_data_event_id",


### PR DESCRIPTION
MQTT compatibility with QoS

Some MQTT brokers do not support qos=2.

Changing transport service to publish with qos=1.
Adding a cache in transport service to avoid sending redundant messages.