### PR TITLE
Correction of transport service logging

### DIFF
--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -926,7 +926,7 @@ def main():
 
     # enable its logger
     logging.basicConfig(
-        format='%(asctime)s | [%(levelname)s] %(name)s@%(filename)s:%(lineno)d:%(message)s',
+        format=f'%(asctime)s | [%(levelname)s] {__pkg_name__}@%(filename)s:%(lineno)d:%(message)s',
         level=debug_level,
         stream=sys.stdout
     )


### PR DESCRIPTION
The logging was using "name" attribute calling the name of a logger that doesn't exist and by default equal to "root". This name has been changed to the package name at the configuration of the logging.


