### PR TITLE
Overflow fix for uint32_t

### DIFF
--- a/python_transport/wirepas_gateway/dbus/sink_manager.py
+++ b/python_transport/wirepas_gateway/dbus/sink_manager.py
@@ -71,7 +71,8 @@ class Sink:
     ):
         try:
             res = self.proxy.SendMessage(
-                dst,
+                # For some reason on some arch, uint32 are not correctly handled
+                dst & 0xFFFFFFFF,
                 src_ep,
                 dst_ep,
                 initial_time,
@@ -206,6 +207,13 @@ class Sink:
         return wmm.GatewayResultCode.GW_RES_OK
 
     def write_config(self, config):
+        # Force the node address if used
+        try:
+            # For some reason on some arch, uint32 are not correctly handled and result to an overflow
+            config["node_address"] = config["node_address"] & 0xFFFFFFFF
+        except KeyError:
+            # Node addess is not in the config
+            pass
         # Should always be available
         try:
             stack_started = (self.proxy.StackStatus & 0x01) == 0


### PR DESCRIPTION
With recent changes (protobuf and python version), it looks like big uint32_t are not handled correctly on some platforms creating issue when used by pydbus.

This is a temporary fix that should be removed when getting read of pydbus.

