### PR TITLE
fix pid location post upgrade to alpine 3.17

### DIFF
--- a/docker/dbus_service/entrypoint.sh
+++ b/docker/dbus_service/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-if [ -f '/var/run/dbus.pid' ]; then
-    rm -f '/var/run/dbus.pid'
+if [ -f '/run/dbus/dbus.pid' ]; then
+    rm -f '/run/dbus/dbus.pid'
 fi
 
 exec dbus-daemon --system --nofork --print-address


### PR DESCRIPTION
The default location for the pid file generated by dbus daemon has changed in alpine 3.17 to /run by default. This PR incorporates the required changes to fix start up failures of dbus services
