### PR TITLE
RTC service force retry sending RTC time

### DIFF
--- a/rtc_service/README.md
+++ b/rtc_service/README.md
@@ -15,6 +15,7 @@ The RTC service needs four parameters to start.
 | WM_RTC_TIMEZONE_OFFSET_S | Timezone offset in seconds of the local time. | It is taken in account only if WM_RTC_TIMEZONE_FROM_GATEWAY_CLOCK is False. |
 | WM_RTC_GET_TIME_FROM_LOCAL | Asserts if the rtc time is sent from local time or from a ntp server time | If set to True, it is assumed that gateways are synchronize. The default value is False |
 | WM_RTC_NTP_SERVER_ADDRESS | Address of the ntp server to query the time if it is taken from an ntp server. | WM_RTC_GET_TIME_FROM_LOCAL must be set to False for that option to be taken into account |
+| WM_RTC_RETRY_PERIOD_S | Period in seconds of the retries sending the rtc time when it couldn't be sent to the network. | It might take additional 5 seconds to know that the rtc time can't be retrieved. |
 
 RTC service is available as a docker image to ease the integration.
 

--- a/rtc_service/rtc_service.py
+++ b/rtc_service/rtc_service.py
@@ -232,7 +232,7 @@ def main():
         default=os.environ.get("WM_RTC_RETRY_PERIOD_S", 1),
         action="store",
         type=str2int,
-        help=("Period of retry sending the the rtc time when it couldn't be sent to the network."
+        help=("Period in seconds of the retries sending the rtc time when it couldn't be sent to the network."
               "Note: It might take additional 5 seconds to know that the rtc time can't be retrieved.")
     )
 


### PR DESCRIPTION
Retry to get the NTP time more frequently when a connection issue happened previously trying to connect to a NTP server.
Catch socket errors that could occur when trying to get the time from a NTP server without a stable connection.

