### PR TITLE
Status update: fix unsent online status

### DIFF
--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -371,6 +371,10 @@ class TransportService(BusClient):
             topic, self._on_otap_set_target_scratchpad_request_received
         )
 
+        # Reset our cached value to be sure the status is published again
+        # If we are here, it means that we were disconnected and our last_will
+        # status was sent
+        self._last_status_config = None
         self._set_status()
 
         logging.info("MQTT connected!")


### PR DESCRIPTION
To avoid too much publish on status topic (that may trigger more traffic from client), there is a cache an the new status is not sent if same as last one (it is retained on broker anyway)

But the cache was not handling the disconnect properly. In case of disconnect, the "last will" update the status but the gateway do not see it and still think that the retained status is the one from its cache.

So the fix is just to clean the cache in the onConnect callback

Closes # .

*Brief pull request description*
