### PR TITLE
Black hole: add an option to stop stack in case of black hole

### DIFF
--- a/python_transport/wirepas_gateway/configure_node.py
+++ b/python_transport/wirepas_gateway/configure_node.py
@@ -183,6 +183,7 @@ class SinkConfigurator(BusClient):
                     print("[%s]: %s" % (key, binascii.hexlify(config[key])))
                 else:
                     print("[%s]: %s" % (key, config[key]))
+            print("[cost]: %d" % (sink.cost))
             print("===================================")
 
 

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -388,6 +388,16 @@ class ParserHelper:
             ),
         )
 
+        self.buffering.add_argument(
+            "--buffering_stop_stack",
+            default=os.environ.get("WM_GW_BUFFERING_STOP_STACK", False),
+            type=self.str2bool,
+            help=(
+                "When true, when a black hole is detected, stack is stopped instead of "
+                " increasing the sink cost"
+            ),
+        )
+
         # This minimal sink cost could be moved somewhere as it can be used even
         # buffering limitation is not in use
         self.buffering.add_argument(


### PR DESCRIPTION
Until now (and still the default) sink cost set to the 254 is the way to prevent the black hole case.
But with this option, it allows to stop the stack instead. It allows testing on large scale networks.

Also add the cost in configure node for easy diagnostic.

