### PR TITLE
Update docker image and build process for transport service

### DIFF
--- a/docker/transport_service/Dockerfile
+++ b/docker/transport_service/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
 		cairo-dev \
 		gobject-introspection-dev
 
-RUN python3 -m pip install wheel setuptools pkgconfig
+RUN python3 -m pip install build
 
 USER wirepas
 WORKDIR /home/wirepas

--- a/docker/transport_service/Dockerfile
+++ b/docker/transport_service/Dockerfile
@@ -1,18 +1,16 @@
-FROM python:3.10.8-alpine3.17 AS builder
+ARG BASE_IMAGE=python:3.13-alpine
+FROM $BASE_IMAGE AS builder
 
 RUN adduser --disabled-password wirepas
 
 RUN apk add --no-cache \
-		gcc \
-		bash \
 		build-base \
-		make \
-		cmake \
-		musl-dev \
+		# Needed for the wheel generation:
+		bash \
 		dpkg \
+		# Needed for dbus_c.c:
 		elogind-dev \
-		python3-dev \
-		py3-gobject3 \
+		# Needed for PyGObject:
 		cairo-dev \
 		gobject-introspection-dev
 
@@ -28,12 +26,11 @@ RUN ./utils/generate_wheel.sh
 
 USER wirepas
 
-RUN pip3 install dist/wirepas_gateway*.whl --no-deps --user
-# Dependencies are installed manually as runner image already have wmm
-# Todo: removing wmm from requirement list would be better
-RUN pip3 install paho-mqtt==1.4.0 pydbus==0.6.0 PyYAML==6.0.1 --user
-RUN pip3 install gobject==0.1.0 PyGObject==3.46.0 --user
+# Needed by pydbus
+RUN pip3 install PyGObject~=3.0 --user
 
+# Install protobuf from source to get the UPB implementation
+RUN pip3 install dist/wirepas_gateway*.whl --no-binary protobuf --user
 
 # Special target to extract binaries
 FROM scratch AS export
@@ -41,9 +38,9 @@ COPY --from=builder /home/wirepas/python_transport/dist/*.tar.gz .
 
 
 # Build the final image with prebuilt wmm image
-FROM wirepas/wmm_alpine_cpp:1.2.5
+FROM $BASE_IMAGE AS runner
 
-USER root
+RUN adduser --disabled-password wirepas
 
 # Variable set from CI
 ARG GATEWAY_BUILD_SHA1=unset
@@ -56,6 +53,11 @@ ENV PATH="/home/wirepas/.local/bin:${PATH}"
 
 # Copy the built wheel and its dependencies from builder
 COPY --from=builder /home/wirepas/.local /home/wirepas/.local
+
+# Sanity check to confirm we have the UPB implementation for protobuf
+RUN python3 -c "import sys;\
+from google.protobuf.internal import api_implementation;\
+sys.exit(0 if api_implementation.Type() == 'upb' else 1)"
 
 CMD ["wm-gw"]
 

--- a/python_transport/README.md
+++ b/python_transport/README.md
@@ -4,17 +4,15 @@
 ## Building the wheel
 
 To build the source distribution and wheel file, make sure you have the
-wheel package installed
+build package installed
 
 ```shell
-   pip install wheel
+   pip install build
 ```
 and then run
 
 ```shell
-   py3clean .
-   python3 setup.py clean --all
-   python3 setup.py sdist bdist_wheel
+   python3 -m build .
 ```
 
 A convenience script is available from the [utils folder][here_utils_wheel].
@@ -60,7 +58,7 @@ Please read on
 
 [wm_gateway_transport_conf]: https://github.com/wirepas/gateway/blob/master/README.md#transport-service-configuration
 [wm_gateway_requirements]: https://github.com/wirepas/gateway/blob/master/README.md#linux-requirements
-[here_utils_wheel]: https://github.com/wirepas/gateway/blob/update-readme/python_transport/utils/generate_wheel.sh
+[here_utils_wheel]: https://github.com/wirepas/gateway/blob/master/python_transport/utils/generate_wheel.sh
 
 [virtualenv]: https://docs.python.org/3/tutorial/venv.html
 [pipenv]: https://github.com/pypa/pipenv

--- a/python_transport/pyproject.toml
+++ b/python_transport/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools>=61.0", "pkgconfig"]
+build-backend = "setuptools.build_meta"
+

--- a/python_transport/setup.py
+++ b/python_transport/setup.py
@@ -92,6 +92,7 @@ setup(
             libraries=get_systemd_lib("libraries"),
             include_dirs=get_systemd_lib("include_dirs"),
             library_dirs=get_systemd_lib("library_dirs"),
+            extra_compile_args=["-Werror"]
         )
     ],
     include_package_data=True,

--- a/python_transport/utils/generate_wheel.sh
+++ b/python_transport/utils/generate_wheel.sh
@@ -2,13 +2,9 @@
 
 set -e
 
-rm -r build || true
 rm -r dist || true
 
-pip install pyclean
-python3 -m pyclean . || true
-python3 setup.py clean --all
-python3 setup.py sdist bdist_wheel
+python3 -m build .
 
 if ! command -v dpkg &>/dev/null; then
   echo "dpkg could not be found!"

--- a/python_transport/wirepas_gateway/dbus/c-extension/dbus_c.c
+++ b/python_transport/wirepas_gateway/dbus/c-extension/dbus_c.c
@@ -81,7 +81,8 @@ static int on_packet_received(sd_bus_message * m, void * userdata, sd_bus_error 
             return -1;
         }
 
-        result = PyEval_CallObject(m_message_callback, arglist);
+        result = PyObject_Call(m_message_callback, arglist, NULL);
+
         if (result == NULL)
         {
             PyErr_Print();
@@ -205,11 +206,6 @@ static struct PyModuleDef dbusCExtension = {PyModuleDef_HEAD_INIT,
  */
 PyMODINIT_FUNC PyInit_dbusCExtension(void)
 {
-    if (!PyEval_ThreadsInitialized())
-    {
-        PyEval_InitThreads();
-    }
-
     int r;
     r = sd_bus_open_system(&m_bus);
     if (r < 0)


### PR DESCRIPTION
Changes are mainly aimed at updating dependencies and to make local building easier. Protobuf python dependency is built in place with the UPB backend, so we don't need to use the base image from [wirepas-mesh-messaging-python](https://github.com/wirepas/wirepas-mesh-messaging-python).

Please see individual commit messages for more details.