### PR TITLE
Fix type to parse boolean parameter #277

### DIFF
--- a/sink_service/source/config.c
+++ b/sink_service/source/config.c
@@ -312,7 +312,7 @@ static bool send_dbus_signal(const char * name)
 static int set_stack_state(sd_bus_message * m, void * userdata, sd_bus_error * error)
 {
     app_res_e res;
-    bool state;
+    int state;
     int r;
 
     /* Read the parameters */


### PR DESCRIPTION
It is specified in documentation from dbus that boolean must be read in a int. https://man7.org/linux/man-pages/man3/sd_bus_message_read.3.html

Closes #277

