### PR TITLE
Update docker base images to alpine v3.21

### DIFF
--- a/docker/dbus_service/Dockerfile
+++ b/docker/dbus_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.0
+FROM alpine:3.21
 
 # Variable set from CI
 ARG GATEWAY_BUILD_SHA1=unset

--- a/docker/local_history_service/Dockerfile
+++ b/docker/local_history_service/Dockerfile
@@ -1,23 +1,21 @@
 # Duplicate of transport service for now
-FROM python:3.10.8-alpine3.17 AS builder
+ARG BASE_IMAGE=python:3.13-alpine3.21
+FROM $BASE_IMAGE AS builder
 
 RUN adduser --disabled-password wirepas
 
 RUN apk add --no-cache \
-		gcc \
-		bash \
 		build-base \
-		make \
-		cmake \
-		musl-dev \
+		# Needed for the wheel generation:
+		bash \
 		dpkg \
+		# Needed for dbus_c.c:
 		elogind-dev \
-		python3-dev \
-		py3-gobject3 \
+		# Needed for PyGObject:
 		cairo-dev \
 		gobject-introspection-dev
 
-RUN python3 -m pip install wheel setuptools pkgconfig
+RUN python3 -m pip install build
 
 USER wirepas
 WORKDIR /home/wirepas
@@ -29,16 +27,17 @@ RUN ./utils/generate_wheel.sh
 
 USER wirepas
 
-RUN pip3 install dist/wirepas_gateway*.whl --no-deps --user
+# Needed by pydbus
+RUN pip3 install PyGObject~=3.0 --user
 
-RUN pip3 install pydbus==0.6.0 PyYAML==6.0.1 --user
-RUN pip3 install gobject==0.1.0 PyGObject==3.46.0 --user
+# Install protobuf from source to get the UPB implementation
+RUN pip3 install dist/wirepas_gateway*.whl --no-binary protobuf --user
 
 
 # Build the final image
-FROM wirepas/wmm_alpine_cpp:1.2.5 as runner
+FROM $BASE_IMAGE AS runner
 
-USER root
+RUN adduser --disabled-password wirepas
 
 # Variable set from CI
 ARG GATEWAY_BUILD_SHA1=unset
@@ -51,6 +50,11 @@ ENV PATH="/home/wirepas/.local/bin:${PATH}"
 
 # Copy the built wheel and its dependencies from builder
 COPY --from=builder /home/wirepas/.local /home/wirepas/.local
+
+# Sanity check to confirm we have the UPB implementation for protobuf
+RUN python3 -c "import sys;\
+from google.protobuf.internal import api_implementation;\
+sys.exit(0 if api_implementation.Type() == 'upb' else 1)"
 
 COPY ./local_history_service/*.py /home/wirepas/local_history_service/
 

--- a/docker/rtc_service/Dockerfile
+++ b/docker/rtc_service/Dockerfile
@@ -1,22 +1,20 @@
-FROM python:3.10.8-alpine3.17 AS builder
+ARG BASE_IMAGE=python:3.13-alpine3.21
+FROM $BASE_IMAGE AS builder
 
 RUN adduser --disabled-password wirepas
 
 RUN apk add --no-cache \
-		gcc \
-		bash \
 		build-base \
-		make \
-		cmake \
-		musl-dev \
+		# Needed for the wheel generation:
+		bash \
 		dpkg \
+		# Needed for dbus_c.c:
 		elogind-dev \
-		python3-dev \
-		py3-gobject3 \
+		# Needed for PyGObject:
 		cairo-dev \
 		gobject-introspection-dev
 
-RUN python3 -m pip install wheel setuptools pkgconfig
+RUN python3 -m pip install build
 
 USER wirepas
 WORKDIR /home/wirepas
@@ -34,18 +32,20 @@ USER wirepas
 # But, they should be splitted later and the dbus client wheel
 # will be independent from the transport service.
 
-RUN pip3 install dist/wirepas_gateway*.whl --no-deps --user
-# Dependencies are installed manually as runner image already have wmm
-# Todo: removing wmm from requirement list would be better
-RUN pip3 install pydbus==0.6.0 PyYAML==6.0.1 --user
-RUN pip3 install gobject==0.1.0 PyGObject==3.46.0 --user
+# Needed by pydbus
+RUN pip3 install PyGObject~=3.0 --user
+
+# Install protobuf from source to get the UPB implementation
+RUN pip3 install dist/wirepas_gateway*.whl --no-binary protobuf --user
+
+# Needed by rtc_service.py
 RUN pip3 install ntplib --user
 
 
-# Build the final image with prebuilt wmm image
-FROM wirepas/wmm_alpine_cpp:1.2.5
+# Build the final image
+FROM $BASE_IMAGE AS runner
 
-USER root
+RUN adduser --disabled-password wirepas
 
 # Variable set from CI
 ARG GATEWAY_BUILD_SHA1=unset

--- a/docker/sink_service/Dockerfile
+++ b/docker/sink_service/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.17 AS builder
+ARG BASE_IMAGE=alpine:3.21
+FROM $BASE_IMAGE AS builder
 
 # Variable set from CI
 ARG GATEWAY_BUILD_SHA1=unset
@@ -22,7 +23,7 @@ RUN make
 FROM scratch AS export
 COPY --from=builder /home/wirepas/sink_service/build/sinkService .
 
-FROM alpine:3.17
+FROM $BASE_IMAGE
 
 # Variable set from CI
 ARG GATEWAY_BUILD_SHA1=unset

--- a/docker/transport_service/Dockerfile
+++ b/docker/transport_service/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.13-alpine
+ARG BASE_IMAGE=python:3.13-alpine3.21
 FROM $BASE_IMAGE AS builder
 
 RUN adduser --disabled-password wirepas
@@ -37,7 +37,7 @@ FROM scratch AS export
 COPY --from=builder /home/wirepas/python_transport/dist/*.tar.gz .
 
 
-# Build the final image with prebuilt wmm image
+# Build the final image
 FROM $BASE_IMAGE AS runner
 
 RUN adduser --disabled-password wirepas


### PR DESCRIPTION
Using python:3.13-alpine3.21 for python based images, since it is based on alpine:3.21 and that should make downloading images faster.

Updating dockerfiles of local_history_service and rtc_service to be based on the newer transport_service dockerfile.

Alpine 3.21 is supported until 2026-11-01