### PR TITLE
Fix missing sd_bus_message_unref calls in sink service

### DIFF
--- a/sink_service/source/config.c
+++ b/sink_service/source/config.c
@@ -281,7 +281,7 @@ static int set_authen_key(sd_bus * bus,
 static bool send_dbus_signal(const char * name)
 {
     /* Create a new signal to be generated on Dbus */
-    sd_bus_message * m = NULL;
+    __attribute__((cleanup(sd_bus_message_unrefp))) sd_bus_message *m = NULL;
     int r = sd_bus_message_new_signal(m_bus, &m, m_object, m_interface, name);
 
     if (r < 0)
@@ -295,12 +295,8 @@ static bool send_dbus_signal(const char * name)
     if (r < 0)
     {
         LOGE("Cannot send signal error=%s\n", strerror(-r));
-        sd_bus_message_unref(m);
         return false;
     }
-
-    /* Release message to free memory */
-    sd_bus_message_unref(m);
 
     return true;
 }
@@ -403,7 +399,7 @@ static int get_app_config(sd_bus_message * m, void * userdata, sd_bus_error * er
     uint8_t app_config[MAX_APP_CONFIG_SIZE];
     uint8_t size;
 
-    sd_bus_message * reply = NULL;
+    __attribute__((cleanup(sd_bus_message_unrefp))) sd_bus_message *reply = NULL;
 
     res = WPC_get_app_config_data_size(&size);
     if (res != APP_RES_OK)

--- a/sink_service/source/data.c
+++ b/sink_service/source/data.c
@@ -157,7 +157,7 @@ static bool onDataReceived(const uint8_t * bytes,
                            uint8_t hop_count,
                            unsigned long long timestamp_ms)
 {
-    sd_bus_message * m = NULL;
+    __attribute__((cleanup(sd_bus_message_unrefp))) sd_bus_message *m = NULL;
     int r;
 
     LOGD("%llu -> Data received on EP %d of len %d from 0x%x to 0x%x\n",
@@ -204,9 +204,6 @@ static bool onDataReceived(const uint8_t * bytes,
 
     /* Send the signal on bus */
     sd_bus_send(m_bus, m, NULL);
-
-    /* Release message to free memory */
-    sd_bus_message_unref(m);
 
     return true;
 }

--- a/sink_service/source/otap.c
+++ b/sink_service/source/otap.c
@@ -187,7 +187,7 @@ static int get_target_scratchpad(sd_bus_message * m, void * userdata, sd_bus_err
     uint8_t action;
     uint8_t param;
 
-    sd_bus_message * reply = NULL;
+    __attribute__((cleanup(sd_bus_message_unrefp))) sd_bus_message *reply = NULL;
 
     res = WPC_read_target_scratchpad(&target_seq, &target_crc, &action, &param);
     if (res != APP_RES_OK)


### PR DESCRIPTION
Missing unref calls caused memory leaks, which might lead to issues similar to #286.

The cleanup variable attribute with sd_bus_message_unrefp is used in systemd source code as well. The cleanup function is called when the variable goes out of scope.