### PR TITLE
Fix failing workflow builds

### DIFF
--- a/.github/workflows/docker_dbus_service.yml
+++ b/.github/workflows/docker_dbus_service.yml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Set tag for push
         if: github.event_name == 'push'
@@ -51,13 +51,13 @@ jobs:
         run: echo "TAG2=$IMAGE_NAME:latest" >> $GITHUB_ENV
 
       - name: Login to docker hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/dbus_service/Dockerfile

--- a/.github/workflows/docker_dbus_service.yml
+++ b/.github/workflows/docker_dbus_service.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        run: sudo apt-get update && sudo apt-get install qemu-user-static -y
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker_local_history_service.yml
+++ b/.github/workflows/docker_local_history_service.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        run: sudo apt-get update && sudo apt-get install qemu-user-static -y
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker_local_history_service.yml
+++ b/.github/workflows/docker_local_history_service.yml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Set tag for push
         if: github.event_name == 'push'
@@ -51,13 +51,13 @@ jobs:
         run: echo "TAG2=$IMAGE_NAME:latest" >> $GITHUB_ENV
 
       - name: Login to docker hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/local_history_service/Dockerfile

--- a/.github/workflows/docker_rtc_service.yml
+++ b/.github/workflows/docker_rtc_service.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        run: sudo apt-get update && sudo apt-get install qemu-user-static -y
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker_rtc_service.yml
+++ b/.github/workflows/docker_rtc_service.yml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Set tag for push
         if: github.event_name == 'push'
@@ -51,13 +51,13 @@ jobs:
         run: echo "TAG2=$IMAGE_NAME:latest" >> $GITHUB_ENV
 
       - name: Login to docker hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/rtc_service/Dockerfile

--- a/.github/workflows/docker_sink_service.yml
+++ b/.github/workflows/docker_sink_service.yml
@@ -26,16 +26,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: get c-mesh-api with submodule
         run: git submodule update --init
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Set tag for push
         if: github.event_name == 'push'
@@ -54,13 +54,13 @@ jobs:
         run: echo "TAG2=$IMAGE_NAME:latest" >> $GITHUB_ENV
 
       - name: Login to docker hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/sink_service/Dockerfile

--- a/.github/workflows/docker_sink_service.yml
+++ b/.github/workflows/docker_sink_service.yml
@@ -32,7 +32,7 @@ jobs:
         run: git submodule update --init
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        run: sudo apt-get update && sudo apt-get install qemu-user-static -y
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker_transport_service.yml
+++ b/.github/workflows/docker_transport_service.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        run: sudo apt-get update && sudo apt-get install qemu-user-static -y
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker_transport_service.yml
+++ b/.github/workflows/docker_transport_service.yml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Set tag for push
         if: github.event_name == 'push'
@@ -51,13 +51,13 @@ jobs:
         run: echo "TAG2=$IMAGE_NAME:latest" >> $GITHUB_ENV
 
       - name: Login to docker hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/transport_service/Dockerfile

--- a/.github/workflows/release_artefacts.yml
+++ b/.github/workflows/release_artefacts.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        run: sudo apt-get update && sudo apt-get install qemu-user-static -y
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release_artefacts.yml
+++ b/.github/workflows/release_artefacts.yml
@@ -9,18 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and extract sinkService
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
             context: .
             file: docker/sink_service/Dockerfile
@@ -30,7 +30,7 @@ jobs:
             outputs: ./artifacts/sinkService/
 
       - name: Build and extract transportService wheel
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/transport_service/Dockerfile


### PR DESCRIPTION
There has been random segmentation faults while building docker images for different platforms. It might have something to do with "ubuntu-latest" runners [starting to point](https://github.com/actions/runner-images/issues/10636) to Ubuntu 24.04 instead of 22.04 in the past weeks. Builds for docker containers were okay around 3 weeks ago when there was still the warning for the 24.04 update (https://github.com/wirepas/gateway/actions).

Looks like we're not the only ones having this problem:
[tonistiigi/binfmt#/215](https://github.com/tonistiigi/binfmt/issues/215)

docker/setup-qemu-action has been using an older version of QEMU (v7.0.0), and maybe there's some incompatibility between host/docker/qemu. I tried installing QEMU from the package manager (should be v8.2.2), and didn't have any build failures with that so far.