### PR TITLE
docker: Fix README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -55,7 +55,7 @@ All the dockerfiles are available in this directory and can be built directly fr
 
 Example to build a custom sink service tagged local/my_sink_service:tag1 in your PC:
 ```bash
-docker build -f docker/sink_service/Dockerfile -t local/my_sink_service:tag1
+docker build -f docker/sink_service/Dockerfile -t local/my_sink_service:tag1 .
 ```
 You can then use this image in the docker-compose template instead of the Wirepas Docker Hub ones.
 


### PR DESCRIPTION
This fixes the `docker build` command:

```
$ docker build -f docker/sink_service/Dockerfile -t local/my_sink_service:tag1 .
gportay@archlinux ~/src/wirepas/gateway $ docker build -f docker/sink_service/Dockerfile -t local/my_sink_service:tag1 .                  
[+] Building 1.1s (15/15) FINISHED                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                               0.1s
 => => transferring dockerfile: 1.03kB                                                                                             0.0s
 => [internal] load metadata for docker.io/library/alpine:3.21                                                                     0.6s
 => [internal] load .dockerignore                                                                                                  0.1s
 => => transferring context: 487B                                                                                                  0.0s
 => [builder 1/7] FROM docker.io/library/alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c       0.0s
 => [internal] load build context                                                                                                  0.1s
 => => transferring context: 9.08kB                                                                                                0.0s
 => CACHED [builder 2/7] RUN adduser --disabled-password wirepas                                                                   0.0s
 => CACHED [stage-2 3/5] RUN addgroup wirepas dialout                                                                              0.0s
 => CACHED [stage-2 4/5] RUN apk add --no-cache libelogind coreutils                                                               0.0s
 => CACHED [builder 3/7] RUN apk add --no-cache gcc make cmake musl-dev dpkg elogind-dev linux-headers                             0.0s
 => CACHED [builder 4/7] WORKDIR /home/wirepas                                                                                     0.0s
 => CACHED [builder 5/7] COPY --chown=wirepas ./sink_service /home/wirepas/sink_service                                            0.0s
 => CACHED [builder 6/7] WORKDIR /home/wirepas/sink_service                                                                        0.0s
 => CACHED [builder 7/7] RUN make                                                                                                  0.0s
 => CACHED [stage-2 5/5] COPY --from=builder /home/wirepas/sink_service/build/sinkService /home/wirepas/                           0.0s
 => exporting to image                                                                                                             0.0s
 => => exporting layers                                                                                                            0.0s
 => => writing image sha256:3d5a3d844680358d58b5f99d69d94fcda717960c2af44a4f19d5c6622c27d6cd                                       0.0s
 => => naming to docker.io/local/my_sink_service:tag1         
```