### PR TITLE
LG-90 Missing error code mappings for CDD operations

### DIFF
--- a/python_transport/wirepas_gateway/dbus/return_code.py
+++ b/python_transport/wirepas_gateway/dbus/return_code.py
@@ -73,6 +73,8 @@ class ReturnCode:
             (27, GatewayResultCode.GW_RES_INVALID_REBOOT_DELAY),
             # APP_RES_INTERNAL_ERROR, WPC internal error
             (28, GatewayResultCode.GW_RES_INTERNAL_ERROR),
+            # APP_RES_OPERATION_NOT_SUPPORTED, Operation not supported
+            (29, GatewayResultCode.GW_RES_ACCESS_DENIED)
         ]
     )
 

--- a/sink_service/CMakeLists.txt
+++ b/sink_service/CMakeLists.txt
@@ -14,7 +14,7 @@ include(FetchContent)
 FetchContent_Declare(
     c-mesh-api
     GIT_REPOSITORY https://github.com/wirepas/c-mesh-api/
-    GIT_TAG c566fdbd693eb3fb6027286679f53db9f9958e0a
+    GIT_TAG 1b8767b9f26717d1819a8043889d58f29f89da13
     SOURCE_SUBDIR lib
 )
 FetchContent_MakeAvailable(c-mesh-api)

--- a/sink_service/source/config.c
+++ b/sink_service/source/config.c
@@ -627,7 +627,12 @@ static int get_cdd_items_and_append_to_message(sd_bus_message *const message,
     const app_res_e wpc_res = WPC_get_config_data_item_list(endpoints,
                                                             sizeof(endpoints),
                                                             &num_of_items);
-    if (APP_RES_OK != wpc_res)
+    if (APP_RES_OPERATION_NOT_SUPPORTED == wpc_res)
+    {
+        LOGW("Stack doesn't support getting config data item list, returning empty list.\n");
+        return 0;
+    }
+    else if (APP_RES_OK != wpc_res)
     {
         SET_WPC_ERROR(error, "WPC_get_config_data_item_list", wpc_res);
         LOGE("Cannot get config data item list (ret=%d)\n", wpc_res);


### PR DESCRIPTION
Getting list of configuration data items would fail with the APP_RES_OPERATION_NOT_SUPPORTED error code only if an older, incompatible version of stack is used with dualmcu_app.

Since getting the list of items is done regularly for the status message in the gateway, such return code is not really an error.