### PR TITLE
Dbus service: switch to 3.22 alpine

### DIFF
--- a/docker/dbus_service/Dockerfile
+++ b/docker/dbus_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.22
 
 # Variable set from CI
 ARG GATEWAY_BUILD_SHA1=unset


### PR DESCRIPTION
It is needed for aarch64.
It looks like dbus daemon hangs for long time with alpine dbus package < 1.16 and in 3.21 is running 1.14

Same issue discussed here:
https://gitlab.alpinelinux.org/alpine/aports/-/issues/16729?__goaway_challenge=cookie&__goaway_id=b879180bbcca727cdd397487276289dd&__goaway_referer=https%3A%2F%2Fwww.google.com%2F

Could be worth upgrading other base image to 3.22
