### PR TITLE
Update paho-mqtt to v2.1.0

### DIFF
--- a/python_transport/requirements.txt
+++ b/python_transport/requirements.txt
@@ -8,4 +8,5 @@ pydbus==0.6.0
 PyYAML==6.0.1
 
 # mqtt
-paho-mqtt==1.4.0
+paho-mqtt==2.1.0
+

--- a/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
+++ b/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
@@ -52,6 +52,8 @@ class MQTTWrapper(Thread):
             self._use_websockets = False
 
         self._client = mqtt.Client(
+            callback_api_version=mqtt.CallbackAPIVersion.VERSION1,
+            protocol=mqtt.MQTTProtocolVersion.MQTTv311,
             client_id=settings.gateway_id,
             clean_session=not settings.mqtt_persist_session,
             transport=transport,
@@ -133,7 +135,7 @@ class MQTTWrapper(Thread):
         if self.on_connect_cb is not None:
             self.on_connect_cb()
 
-    def _on_disconnect(self, userdata, rc):
+    def _on_disconnect(self, client, userdata, rc):
         if rc != 0:
             logging.error(
                 "MQTT unexpected disconnection (network or broker originated):"
@@ -172,19 +174,6 @@ class MQTTWrapper(Thread):
                     topic, payload, qos, retain = self._publish_queue.get()
                     info = self._client.publish(topic, payload, qos=qos, retain=retain)
                     self._unpublished_mid_set.add(info.mid)
-
-                    # FIX: read internal sockpairR as it is written but
-                    # never read as we don't use the internal paho loop
-                    # but we have spurious timeout / broken pipe from
-                    # this socket pair
-                    # pylint: disable=protected-access
-                    try:
-                        self._client._sockpairR.recv(1)
-                    except Exception:
-                        # This socket is not used at all, so if something is wrong,
-                        # not a big issue. Just keep going
-                        pass
-
             except queue.Empty:
                 # No more packet to publish
                 pass

--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -436,10 +436,6 @@ class TransportService(BusClient):
             last_will_message,
         )
 
-        self.mqtt_wrapper.start()
-
-        logging.info("Gateway started with id: %s", self.gw_id)
-
         self.monitoring_thread = None
         self.minimum_sink_cost = settings.buffering_minimal_sink_cost
 
@@ -480,6 +476,10 @@ class TransportService(BusClient):
 
         # Dictionnary to store scratchpad chunks
         self._scratchpad_chunks = {}
+
+        self.mqtt_wrapper.start()
+
+        logging.info("Gateway started with id: %s", self.gw_id)
 
 
     def _on_mqtt_wrapper_termination_cb(self):


### PR DESCRIPTION
Using library callback API version 1 which is deprecated for an easier transition. Also explicitly setting the protocol version to v3.1.1 (which is the default anyway) because current callbacks won't work with MQTTv5.

Removing the _sockpairR workaround because in paho-mqtt v2.1.0, it is not initialized when not using client.loop() or client.loop_start(), which is our case and therefore not needed anymore.

mqtt_wrapper.start() is moved to the end of the constructor of TransportService class because if MQTT CONNACK is received too soon, transport service was crashing due to status_thread not being initialized.

Also fixing the callback function signature for _on_disconnect.

Note: _sockpairR issue can be tested by running the transport service and investigating the local tcp sockets with `ss -tmp | grep wm-gw`. With the older version if you disable the workaround, send buffer of one of the sockets fills up as messages are published. With the new version, the extra 2 sockets don't get created.
