### PR TITLE
Fix build for rtc_service and local_history_service

### DIFF
--- a/docker/local_history_service/Dockerfile
+++ b/docker/local_history_service/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /home/wirepas
 COPY --chown=wirepas ./python_transport /home/wirepas/python_transport
 WORKDIR /home/wirepas/python_transport
 
-RUN ./utils/generate_wheel.sh
+RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_WIREPAS_GATEWAY=0.0.0 ./utils/generate_wheel.sh
 
 USER wirepas
 

--- a/docker/rtc_service/Dockerfile
+++ b/docker/rtc_service/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /home/wirepas
 COPY --chown=wirepas ./python_transport /home/wirepas/python_transport
 WORKDIR /home/wirepas/python_transport
 
-RUN ./utils/generate_wheel.sh
+RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_WIREPAS_GATEWAY=0.0.0 ./utils/generate_wheel.sh
 
 USER wirepas
 


### PR DESCRIPTION
Transport service wheel is used in these services for its dbus client (as mentioned in the comment in the dockerfiles). With recent changes, transport service build needs to be given the version.

A dummy version is now given when building the transport service wheel for these services. This is okay because the version of the transport service is not used in these services.

Should fix the following failed builds:
https://github.com/wirepas/gateway/actions/runs/23045402437
https://github.com/wirepas/gateway/actions/runs/23045402494
