### PR TITLE
Update base images and protobuf

### DIFF
--- a/docker/dbus_service/Dockerfile
+++ b/docker/dbus_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22
+FROM alpine:3.23
 
 # Variable set from CI
 ARG GATEWAY_BUILD_SHA1=unset

--- a/docker/local_history_service/Dockerfile
+++ b/docker/local_history_service/Dockerfile
@@ -1,5 +1,5 @@
 # Duplicate of transport service for now
-ARG BASE_IMAGE=python:3.13-alpine3.21
+ARG BASE_IMAGE=python:3.13-alpine3.23
 FROM $BASE_IMAGE AS builder
 
 RUN adduser --disabled-password wirepas

--- a/docker/rtc_service/Dockerfile
+++ b/docker/rtc_service/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.13-alpine3.21
+ARG BASE_IMAGE=python:3.13-alpine3.23
 FROM $BASE_IMAGE AS builder
 
 RUN adduser --disabled-password wirepas

--- a/docker/sink_service/Dockerfile
+++ b/docker/sink_service/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.21
+ARG BASE_IMAGE=alpine:3.23
 FROM $BASE_IMAGE AS builder
 
 # Variable set from CI

--- a/docker/transport_service/Dockerfile
+++ b/docker/transport_service/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.13-alpine3.21
+ARG BASE_IMAGE=python:3.13-alpine3.23
 ARG WM_TRANSPORT_VERSION=0.0.0.dev0
 
 FROM $BASE_IMAGE AS builder

--- a/python_transport/requirements.txt
+++ b/python_transport/requirements.txt
@@ -1,5 +1,5 @@
 # wirepas
-wirepas_mesh_messaging==1.3.0
+wirepas_mesh_messaging==1.4.1
 
 # dbus bindings
 pydbus==0.6.0


### PR DESCRIPTION
wirepas_mesh_messaging 1.4.1 depends on a newer protobuf version (6.33.5) which should fix vulnerabilities such as [CVE-2026-0994](https://avd.aquasec.com/nvd/2026/cve-2026-0994/).


Latest python base image for 3.13-alpine3.21 seems to be using alpine 3.21.5, so it misses fixes introduced in 3.21.6. In fact it looks like there are no new python base images being built with alpine 3.21 (https://github.com/docker-library/python/tree/master/3.13). Therefore, updating all of the base images to be based on alpine 3.23.