### PR TITLE
Print commit hash as sink service version

### DIFF
--- a/docker/sink_service/Dockerfile
+++ b/docker/sink_service/Dockerfile
@@ -16,7 +16,10 @@ WORKDIR /home/wirepas
 
 COPY --chown=wirepas ./sink_service /home/wirepas/sink_service
 
-RUN CMAKE_BUILD_TYPE=Release cmake -S /home/wirepas/sink_service -B /home/wirepas/build
+RUN CMAKE_BUILD_TYPE=Release cmake \
+  -S /home/wirepas/sink_service \
+  -B /home/wirepas/build \
+  -DSINK_SERVICE_VERSION="${GATEWAY_BUILD_SHA1}"
 RUN cmake --build /home/wirepas/build
 
 FROM scratch AS export

--- a/sink_service/CMakeLists.txt
+++ b/sink_service/CMakeLists.txt
@@ -10,11 +10,15 @@ set(CMAKE_C_FLAGS_RELEASE "-O2")
 
 add_compile_options(-Wall -Werror -Wextra -Wno-unused-parameter)
 
+set(SINK_SERVICE_VERSION "<unknown>" CACHE STRING "Sink service version string")
+
+set(C_MESH_API_COMMIT_HASH b70b379c8bb4f44b151f99d0af321abe84b63455)
+
 include(FetchContent)
 FetchContent_Declare(
     c-mesh-api
     GIT_REPOSITORY https://github.com/wirepas/c-mesh-api/
-    GIT_TAG b70b379c8bb4f44b151f99d0af321abe84b63455
+    GIT_TAG ${C_MESH_API_COMMIT_HASH}
     SOURCE_SUBDIR lib
 )
 FetchContent_MakeAvailable(c-mesh-api)
@@ -27,6 +31,11 @@ add_executable(${CMAKE_PROJECT_NAME}
     source/config.c
     source/data.c
     source/otap.c
+)
+
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
+    SINK_SERVICE_VERSION="${SINK_SERVICE_VERSION}"
+    C_MESH_API_COMMIT_HASH="${C_MESH_API_COMMIT_HASH}"
 )
 
 target_link_libraries(${CMAKE_PROJECT_NAME} wpc PkgConfig::systemd)

--- a/sink_service/source/main.c
+++ b/sink_service/source/main.c
@@ -300,6 +300,33 @@ static bool setup_signal_handlers_for_stopping()
     return true;
 }
 
+static void print_version_to_stdout()
+{
+    printf("Sink service version: %s\n", SINK_SERVICE_VERSION);
+    printf("c-mesh-api version: %s\n", C_MESH_API_COMMIT_HASH);
+}
+
+static void print_version_to_log()
+{
+    LOGI("Sink service version: %s\n", SINK_SERVICE_VERSION);
+    LOGI("c-mesh-api version: %s\n", C_MESH_API_COMMIT_HASH);
+}
+
+static void print_usage()
+{
+    printf("Parameters:\n"
+           " -b <baudrate>                 UART BAUD rate\n"
+           " -p <port_name>                UART port\n"
+           " -i <sink_id>                  sink ID\n"
+           " -d <max_poll_fail_duration>   max poll fail duration\n"
+           " -f <fragment_max_duration_s>  fragment max duration\n"
+           " -l <downlink_limit>           downlink limit\n"
+           "\n"
+           " -V  display version\n"
+           " -h  display this help message\n"
+    );
+}
+
 int main(int argc, char * argv[])
 {
     unsigned long baudrate = 0;
@@ -324,14 +351,13 @@ int main(int argc, char * argv[])
                        &fragment_max_duration_s, &downlink_limit);
 
     /* Parse command line arguments - take precedence over environmental ones */
-    while ((c = getopt(argc, argv, "b:p:i:d:f:l:")) != -1)
+    while ((c = getopt(argc, argv, "b:p:i:d:f:l:Vh")) != -1)
     {
         switch (c)
         {
             case 'b':
                 /* Get the baudrate */
                 baudrate = strtoul(optarg, NULL, 0);
-                LOGI("Baudrate set to %d\n", baudrate);
                 break;
             case 'p':
                 /* Get the port name */
@@ -350,13 +376,19 @@ int main(int argc, char * argv[])
             case 'l':
                 downlink_limit = strtoul(optarg, NULL, 0);
                 break;
+            case 'V':
+                print_version_to_stdout();
+                return EXIT_SUCCESS;
+            case 'h':
+                print_usage();
+                return EXIT_SUCCESS;
             case '?':
             default:
-                LOGE("Error in argument parsing\n");
-                LOGE("Parameters are: -b <baudrate> -p <port> -i <sink_id> -f <fragment max duration> -l <downlink limit>\n");
+                fprintf(stderr, "Try -h parameter for help.\n");
                 return EXIT_FAILURE;
         }
     }
+    print_version_to_log();
 
     if (downlink_limit > 16)
     {


### PR DESCRIPTION
The sink service and c-mesh-api commit hashes are now printed during sink service startup. This makes it easier to check what version has been running when using the "edge" tagged docker images.

Note: Earlier docker images also had this information in the label of the image, which can be checked with:
`docker inspect --format '{{.Config.Labels}}' wirepas/gateway_sink_service:edge`