### PR TITLE
Set cost for existing sinks also when black hole detection is disabled

### DIFF
--- a/python_transport/wirepas_gateway/dbus/sink_manager.py
+++ b/python_transport/wirepas_gateway/dbus/sink_manager.py
@@ -418,6 +418,8 @@ class Sink:
         if new_cost is None or new_cost < 0 or new_cost > 254:
             raise ValueError("Wrong sink cost value {}".format(new_cost))
 
+        logging.debug(f"Setting cost {new_cost} for sink {self.sink_id}")
+
         try:
             self.proxy.SinkCost = new_cost
         except GLib.Error as err:
@@ -842,3 +844,8 @@ class SinkManager:
         except KeyError:
             logging.error("Unknown sink %s from sink list", short_name)
             return None
+
+    def set_sink_costs(self, cost):
+        for sink in self.get_sinks():
+            sink.cost = cost
+

--- a/python_transport/wirepas_gateway/dbus/sink_manager.py
+++ b/python_transport/wirepas_gateway/dbus/sink_manager.py
@@ -846,6 +846,12 @@ class SinkManager:
             return None
 
     def set_sink_costs(self, cost):
+        """
+        Sets sink cost for all the existing sinks
+
+        Args:
+            cost: new sink cost
+        """
+
         for sink in self.get_sinks():
             sink.cost = cost
-

--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -76,10 +76,6 @@ class ConnectionToBackendMonitorThread(Thread):
         self.max_delay_without_publish = max_delay_without_publish
         self.stop_stack = stop_stack
 
-    def _set_sinks_cost(self, cost):
-        for sink in self.sink_manager.get_sinks():
-            sink.cost = cost
-
     def _stop_sinks(self):
         for sink in self.sink_manager.get_sinks():
             sink.write_config({"started": False})
@@ -89,10 +85,10 @@ class ConnectionToBackendMonitorThread(Thread):
             sink.write_config({"started": True})
 
     def _set_sinks_cost_high(self):
-        self._set_sinks_cost(self.SINK_COST_HIGH)
+        self.sink_manager.set_sink_costs(self.SINK_COST_HIGH)
 
     def _set_sinks_cost_low(self):
-        self._set_sinks_cost(self.minimum_sink_cost)
+        self.sink_manager.set_sink_costs(self.minimum_sink_cost)
 
     def _is_publish_delay_over(self):
         if self.max_delay_without_publish <= 0:
@@ -115,9 +111,6 @@ class ConnectionToBackendMonitorThread(Thread):
         Main loop that check periodically the status of the published queue and compare
         it to threshold set when starting Transport
         """
-
-        # Initialize already detected sinks
-        self._set_sinks_cost_low()
 
         self.running = True
 
@@ -438,6 +431,7 @@ class TransportService(BusClient):
 
         self.monitoring_thread = None
         self.minimum_sink_cost = settings.buffering_minimal_sink_cost
+        self.sink_manager.set_sink_costs(self.minimum_sink_cost)
 
         if settings.buffering_max_buffered_packets > 0 or settings.buffering_max_delay_without_publish > 0:
             logging.info(


### PR DESCRIPTION
Existing sinks are detected at startup in the constructor of SinkManager by listing bus objects matching the sink service names.

Earlier, the cost for these existing sinks was only initialized when the black hole detection was enabled, when ConnectionToBackendMonitorThread is run.

After the sink cost has been increased due to MQTT disconnection, if the gateway is stopped before MQTT is re-connected, we end up with a sink with increased cost. At this point if the gateway is reconfigured to disable the black hole detection sink can get stuck with the increased cost.

To avoid that, the sink costs are now initialized also if the ConnectionToBackendMonitorThread is not started.
