### PR TITLE
LG-99 Only warn when sink cost cannot be set due to invalid role

### DIFF
--- a/python_transport/wirepas_gateway/dbus/sink_manager.py
+++ b/python_transport/wirepas_gateway/dbus/sink_manager.py
@@ -426,7 +426,6 @@ class Sink:
             res = ReturnCode.error_from_dbus_exception(err.message)
             if res == wmm.GatewayResultCode.GW_RES_INVALID_ROLE:
                 logging.warning("Node role is not a sink, sink cost cannot be modified")
-                raise ValueError("Wrong role to set cost value {}".format(new_cost))
             else:
                 logging.error("Cannot set sink cost for sink {} ({})".format(self.sink_id, res))
 

--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -656,10 +656,7 @@ class TransportService(BusClient):
                         name, self.minimum_sink_cost
                     )
                 )
-                try:
-                    sink.cost = self.minimum_sink_cost
-                except ValueError:
-                    logging.debug("Cannot set cost, probably not a sink")
+                sink.cost = self.minimum_sink_cost
 
     @update_gateway_status_dec
     def on_sink_disconnected(self, name):


### PR DESCRIPTION
Starting with commit 1a3eae3 sink cost is set for existing sinks at startup. This can fail if the node role is not sink, for example with a freshly flashed node.

Before this fix, transport service would crash at startup if the node was not a sink because of this. Now these failures are only warnings and the transport service can be started with a node with non-sink role.
