### PR TITLE
Fix boolean type in SendMessage dbus method

### DIFF
--- a/sink_service/source/data.c
+++ b/sink_service/source/data.c
@@ -62,6 +62,7 @@ static int send_message(sd_bus_message * m, void * userdata, sd_bus_error * erro
     int r;
     uint8_t qos;
     size_t weight = 0;
+    int is_unack_csma_ca = 0;
 
     /* Read the parameters */
     r = sd_bus_message_read(m,
@@ -71,7 +72,7 @@ static int send_message(sd_bus_message * m, void * userdata, sd_bus_error * erro
                             &message.dst_ep,
                             &message.buffering_delay,
                             &qos,
-                            &message.is_unack_csma_ca,
+                            &is_unack_csma_ca,
                             &message.hop_limit);
     if (r < 0)
     {
@@ -82,6 +83,8 @@ static int send_message(sd_bus_message * m, void * userdata, sd_bus_error * erro
 
     /* Update QoS Enum field (in case app_qos_e is encoded on more than 1 byte) */
     message.qos = qos;
+
+    message.is_unack_csma_ca = is_unack_csma_ca;
 
     r = sd_bus_message_read_array(m, 'y', &data, &n);
     if (r < 0)


### PR DESCRIPTION
sd-bus uses int C type for booleans in dbus messages (see [sd_bus_message_read(3)](https://www.freedesktop.org/software/systemd/man/latest/sd_bus_message_read.html)).

**Note:** We also have a [HANDLER_READ](https://github.com/wirepas/gateway/blob/20f2804c7517eec24aae47c0443812d01e53fe10/sink_service/source/config_macros.h#L91) macro calling sd_bus_message_append on a dbus boolean type with a C boolean type.

[ sd_bus_message_append](https://www.freedesktop.org/software/systemd/man/latest/sd_bus_message_append.html) is variadic and the bool is supposed to be [promoted to int](https://en.cppreference.com/c/language/conversion#Default_argument_promotions), so we are fine with that one and can keep it untouched.