### PR TITLE
Limit size of SelectableQueue in transport service

### DIFF
--- a/docker/docker-compose/README.md
+++ b/docker/docker-compose/README.md
@@ -66,8 +66,8 @@ The list of all possible parameters to configure the transport service are given
 | WM_SERVICES_MQTT_RECONNECT_DELAY | Delay in seconds to try to reconnect when connection to broker is lost (0 to try forever) | 0 | Any integer |
 | WM_SERVICES_MQTT_MAX_INFLIGHT_MESSAGES | Max inflight messages for messages with qos > 0 | 20 | Any integer |
 | WM_SERVICES_MQTT_USE_WEBSOCKET | When true the mqtt client will use websocket instead of TCP for transport | false | "yes", "true", "t", "y",  "1","no", "false", "f", "n", "0", "" |
-| WM_GW_BUFFERING_MAX_BUFFERED_PACKETS | Maximum number of messages to buffer before rising sink cost (0 will disable feature) | 0 | Any integer |
-| WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH | Maximum time to wait in seconds without any successful publish with packet queued before rising sink cost (0 will disable feature) | 0 | Any integer |
+| WM_GW_BUFFERING_MAX_BUFFERED_PACKETS | Maximum number of messages to buffer before taking an action (see WM_GW_BUFFERING_ACTION) (0 will disable feature) | 0 | Any integer |
+| WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH | Maximum time to wait in seconds without any successful publish with packet queued before taking an action (see WM_GW_BUFFERING_ACTION) (0 will disable feature) | 0 | Any integer |
 | WM_GW_BUFFERING_MINIMAL_SINK_COST | Minimal sink cost for a sink on this gateway. Can be used to minimize traffic on a gateway, but it will reduce maximum number of hops for this gateway | 0 | Any integer |
 | WM_GW_ID | Id of the gateway. It must be unique on same broker | None | Any string |
 | WM_GW_MODEL | Model name of the gateway | None | Any string | 
@@ -75,7 +75,7 @@ The list of all possible parameters to configure the transport service are given
 | WM_GW_IGNORED_ENDPOINTS_FILTER | Destination endpoints list to ignore (not published) | None | List of endpoints (i.e. [1,2,3]), a range of endpoints (i.e. [1-3]), or a combination of both |
 | WM_GW_WHITENED_ENDPOINTS_FILTER | Destination endpoints list to whiten (no payload content, only size) | None | List of endpoints (i.e. [1,2,3]), a range of endpoints (i.e. [1-3]), or a combination of both |
 | WM_SERVICES_MQTT_RATE_LIMIT_PPS | Max rate limit for the mqtt client to publish on mqtt broker | 0 | Any integer |
-| WM_GW_BUFFERING_STOP_STACK | When true, when a black hole is detected, stack is stopped instead of increasing the sink cost | false | "yes", "true", "t", "y",  "1","no", "false", "f", "n", "0", "" |
+| WM_GW_BUFFERING_ACTION | Action to take when the buffer limit is reached or a black hole is detected. | raise_sink_cost | -`raise_sink_cost`: Increases the sink cost<br />-`stop_stack`: Stops the sink stack<br />-`drop_packets`: Limits the publish queue size (Can only be used with WM_GW_BUFFERING_MAX_BUFFERED_PACKETS.) |
 | WM_SERVICES_DEBUG_INCR_EVENT_ID | When true the data received event id will be incremental starting at 0 when service starts. Otherwise it will be random 64 bits id | false | "yes", "true", "t", "y",  "1","no", "false", "f", "n", "0", "" |
 | WM_DEBUG_LEVEL | Configure log level for the transport service. Please be aware that levels such as debug should not be used in a production system | info | debug, info, critical, fatal, error, warning |
 

--- a/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
+++ b/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
@@ -6,6 +6,7 @@ import logging
 import queue
 import socket
 import ssl
+from collections import deque
 from select import select
 from threading import Thread, Lock
 from time import sleep, monotonic
@@ -13,6 +14,8 @@ from random import randrange
 
 from paho.mqtt import client as mqtt
 from paho.mqtt.client import connack_string
+
+from wirepas_gateway.utils.argument_tools import BufferingAction
 
 
 class MQTTWrapper(Thread):
@@ -115,7 +118,13 @@ class MQTTWrapper(Thread):
         if not self._use_websockets and self._client.socket() is not None:
             self._client.socket().setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 2048)
 
-        self._publish_queue = SelectableQueue(rate_limit_pps=settings.mqtt_rate_limit_pps)
+        max_queue_size = None
+        if settings.buffering_action == BufferingAction.DROP_PACKETS:
+            max_queue_size = settings.buffering_max_buffered_packets
+        self._publish_queue = SelectableQueue(
+            rate_limit_pps=settings.mqtt_rate_limit_pps,
+            max_size=max_queue_size,
+        )
         if settings.mqtt_rate_limit_pps >= 0:
             logging.info("Rate control set to %s", settings.mqtt_rate_limit_pps)
 
@@ -284,8 +293,11 @@ class MQTTWrapper(Thread):
 
         """
         # Send it to the queue to be published from Mqtt thread
-        self._publish_queue.put((topic, payload, qos, retain))
-        self._publish_monitor.on_publish_request()
+        if self._publish_queue.put((topic, payload, qos, retain)):
+            # Only count the request if the queue grew. If a queued message was
+            # replaced due to queue size limit, the pending message count stays
+            # the same.
+            self._publish_monitor.on_publish_request()
 
     def subscribe(self, topic, cb, qos=2) -> None:
         logging.debug("Subscribing to: {}".format(topic))
@@ -301,17 +313,24 @@ class MQTTWrapper(Thread):
         return self._publish_monitor.get_publish_waiting_time_s()
 
 
-class SelectableQueue(queue.LifoQueue):
+class SelectableQueue:
     """
-    Wrapper arround a Queue to make it selectable with an associated
-    socket and with a built-in rate limit in term of reading
+    LIFO queue made selectable with an associated socket pair
+    and with a built-in rate limit in term of reading
+
+    When max_size is given and the limit is reached, each insertion to the
+    queue drops the oldest element so that the queue size stays the same.
 
     Args:
-        rate_limit_pps: maximum number of get during one second, None for unlimited
+        rate_limit_pps: maximum number of get during one second, None for
+                        unlimited
+        max_size: maximum number of items the queue can hold. None or 0 for
+                  unlimited
     """
 
-    def __init__(self, rate_limit_pps=None):
-        super().__init__()
+    DROP_LOG_PERIOD_S = 60
+
+    def __init__(self, rate_limit_pps=None, max_size=None):
         self._putsocket, self._getsocket = socket.socketpair()
         if rate_limit_pps == 0:
             # 0 is same as no limit
@@ -320,7 +339,14 @@ class SelectableQueue(queue.LifoQueue):
         self._get_ts_list = list()
         self._signal_scheduled = False
         self._signaled = False
-        self._signal_lock = Lock()
+        if max_size is not None and max_size <= 0:
+            max_size = None
+        if max_size is not None:
+            logging.info(f"Publish queue size limited to {max_size}")
+        self._queue = deque(maxlen=max_size)
+        self._dropped_count = 0
+        self._last_drop_log_ts = monotonic()
+        self._lock = Lock()
 
     def fileno(self):
         """
@@ -329,40 +355,76 @@ class SelectableQueue(queue.LifoQueue):
         """
         return self._getsocket.fileno()
 
-    def put(self, item, block=True, timeout=None):
-        # Insert item in queue
-        super().put(item, block, timeout)
-        self._signal()
+    def put(self, item):
+        """
+        Insert an item in the queue.
 
-    def _signal(self, delay_s=0):
-        with self._signal_lock:
-            if self._signaled:
-                return
+        Returns:
+            True if the queue size increased, False if the oldest item was
+            dropped to make room for the new one (queue full).
+        """
+        with self._lock:
+            previous_len = len(self._queue)
+            self._queue.append(item)
+            new_len = len(self._queue)
+            increased = previous_len != new_len
+            if not increased:
+                self._dropped_count += 1
+            drop_log = self._check_and_get_drop_log_locked()
+            self._signal_locked()
 
-            if self._signal_scheduled:
-                return
+        if drop_log is not None:
+            logging.warning(drop_log)
 
-            def _signal_with_delay(delay_s):
-                sleep(delay_s)
-                with self._signal_lock:
-                    self._signal_scheduled = False
-                    self._putsocket.send(b"x")
-                    self._signaled = True
+        return increased
 
-            if delay_s > 0:
-                self._signal_scheduled = True
-                Thread(target=_signal_with_delay, args=[delay_s]).start()
-            else:
-                # No delay needed, signal directly
-                self._putsocket.send(b"x")
-                self._signaled = True
+    def _check_and_get_drop_log_locked(self):
+        if self._dropped_count <= 0:
+            return None
 
-    def _unsignal(self):
-        with self._signal_lock:
+        now = monotonic()
+        elapsed = now - self._last_drop_log_ts
+        if elapsed < self.DROP_LOG_PERIOD_S:
+            return None
+
+        report = f"Dropped {self._dropped_count} MQTT messages in the last {int(elapsed)} seconds"
+        self._dropped_count = 0
+        self._last_drop_log_ts = now
+
+        return report
+
+    def _signal_locked(self):
+        if self._signaled or self._signal_scheduled:
+            return
+
+        self._putsocket.send(b"x")
+        self._signaled = True
+
+    def _schedule_signal_locked(self, delay_s):
+        if self._signaled or self._signal_scheduled:
+            return
+
+        if delay_s is not None and delay_s > 0:
+            self._signal_scheduled = True
+            Thread(target=self._signal_after_delay, args=[delay_s]).start()
+        else:
+            # No delay needed, signal directly
+            self._putsocket.send(b"x")
+            self._signaled = True
+
+    def _signal_after_delay(self, delay_s):
+        sleep(delay_s)
+        with self._lock:
+            self._signal_scheduled = False
+            self._putsocket.send(b"x")
+            self._signaled = True
+
+    def _consume_signal_locked(self):
+        if self._signaled:
             self._getsocket.recv(1)
             self._signaled = False
 
-    def _get_current_rate(self):
+    def _get_current_rate_locked(self):
         # First of all, remove the element that are older than 1 second
         now = monotonic()
         for i in range(len(self._get_ts_list) - 1, -1, -1):
@@ -372,12 +434,12 @@ class SelectableQueue(queue.LifoQueue):
 
         return len(self._get_ts_list)
 
-    def _get_next_time(self):
+    def _get_next_time_locked(self):
         # Compute when next room will be available
         # in moving window
         # Return value is between 0 and 1
 
-        # Note that _get_current_rate should have been called before
+        # Note that _get_current_rate_locked should have been called before
         # so that items are all queued for less than 1s
         now = monotonic()
         if len(self._get_ts_list) > 0:
@@ -387,43 +449,51 @@ class SelectableQueue(queue.LifoQueue):
 
             return 0
 
-    def _is_rate_limit_reached(self):
+    def _is_rate_limit_reached_locked(self):
         # Rate limit is computed on last second
         if self.rate_limit_pps is None:
             # No rate control
             return False
 
-        if self._get_current_rate() >= self.rate_limit_pps:
+        if self._get_current_rate_locked() >= self.rate_limit_pps:
             # We have reached rate limit
             # compute when new room is present
-            logging.debug("Over the rate limit still {} paquet queued".format(self.qsize()))
+            logging.debug("Over the rate limit still {} paquet queued".format(len(self._queue)))
             # How many time remains for first entry
             return True
 
         return False
 
     def get(self):
-        if self._is_rate_limit_reached():
-            # We are over the limit so clear select
-            self._unsignal()
-            # Start a task to signal available messages
-            self._signal(delay_s=self._get_next_time())
-            # There is something to get but rate limit is reached
-            # so it is empty from consumer point of view
-            raise queue.Empty
+        """
+        Get the most recent item from the queue.
 
-        # Get item first so get can be called and
-        # raise empty exception
-        try:
-            item = super().get(False, None)
-            # If rate limt set, add the get
+        Raises:
+            queue.Empty if there is nothing to get or the rate limit is reached
+        """
+        with self._lock:
+            if self._is_rate_limit_reached_locked():
+                # We are over the limit so clear select
+                self._consume_signal_locked()
+                # Start a task to signal available messages
+                self._schedule_signal_locked(self._get_next_time_locked())
+                # There is something to get but rate limit is reached
+                # so it is empty from consumer point of view
+                raise queue.Empty
+
+            # Get item first so pop can be called and
+            # raise empty exception
+            try:
+                item = self._queue.pop()
+            except IndexError:
+                self._consume_signal_locked()
+                raise queue.Empty
+
+            # If rate limit set, add the get
             if self.rate_limit_pps is not None:
                 self._get_ts_list.append(monotonic())
 
             return item
-        except queue.Empty as e:
-            self._unsignal()
-            raise e
 
 
 class PublishMonitor:

--- a/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
+++ b/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
@@ -9,7 +9,6 @@ import ssl
 from select import select
 from threading import Thread, Lock
 from time import sleep, monotonic
-from datetime import datetime
 from random import randrange
 
 from paho.mqtt import client as mqtt
@@ -466,8 +465,7 @@ class PublishMonitor:
             if self._size == 0:
                 return 0
             else:
-                delta = datetime.now() - self._last_publish_event_timestamp
-                return delta.total_seconds()
+                return monotonic() - self._last_publish_event_timestamp
 
     def on_publish_request(self):
         """
@@ -475,7 +473,7 @@ class PublishMonitor:
         """
         with self._lock:
             if self._size == 0:
-                self._last_publish_event_timestamp = datetime.now()
+                self._last_publish_event_timestamp = monotonic()
             self._size = self._size + 1
 
     def on_publish_done(self):
@@ -484,4 +482,4 @@ class PublishMonitor:
         """
         with self._lock:
             self._size = self._size - 1
-            self._last_publish_event_timestamp = datetime.now()
+            self._last_publish_event_timestamp = monotonic()

--- a/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
+++ b/python_transport/wirepas_gateway/protocol/mqtt_wrapper.py
@@ -429,8 +429,19 @@ class SelectableQueue(queue.LifoQueue):
 
 class PublishMonitor:
     """
-        Object dedicated to MQTT publish monitoring, in a simple
-        and "Thread-safe" way.
+    Thread-safe monitor for outstanding MQTT publishes.
+
+    "Size" is the number of publishes that have been requested
+    (on_publish_request) but not yet completed (on_publish_done, i.e.
+    acknowledged by the MQTT broker).
+
+    It is NOT the number of items currently held in MQTTWrapper._publish_queue.
+    An item stays counted from the moment it is requested until the broker
+    confirms it, including while it sits in the queue and while it is in flight
+    to the broker.
+
+    It also keeps the timestamp of the last publish event, used to measure how
+    long publishing has been stalled (i.e. disconnected from broker).
     """
 
     def __init__(self):
@@ -439,10 +450,18 @@ class PublishMonitor:
         self._last_publish_event_timestamp = 0  # valid if size != 0
 
     def get_publish_queue_size(self):
+        """
+        Return the number of publishes requested but not yet completed.
+        """
         with self._lock:
             return self._size
 
     def get_publish_waiting_time_s(self):
+        """
+        Return the seconds elapsed since the last publish event while publishes
+        are still outstanding, or 0 if none are pending. A growing value means
+        publishing is stalled.
+        """
         with self._lock:
             if self._size == 0:
                 return 0
@@ -451,12 +470,18 @@ class PublishMonitor:
                 return delta.total_seconds()
 
     def on_publish_request(self):
+        """
+        Register that a publish has been requested.
+        """
         with self._lock:
             if self._size == 0:
                 self._last_publish_event_timestamp = datetime.now()
             self._size = self._size + 1
 
     def on_publish_done(self):
+        """
+        Register that a publish has completed (acknowledged by the broker).
+        """
         with self._lock:
             self._size = self._size - 1
             self._last_publish_event_timestamp = datetime.now()

--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -15,6 +15,7 @@ from wirepas_gateway.dbus.dbus_client import BusClient
 from wirepas_gateway.protocol.topic_helper import TopicGenerator, TopicParser
 from wirepas_gateway.protocol.mqtt_wrapper import MQTTWrapper
 from wirepas_gateway.utils import ParserHelper
+from wirepas_gateway.utils.argument_tools import BufferingAction
 
 from wirepas_gateway import __version__ as transport_version
 from wirepas_gateway import __pkg_name__
@@ -75,6 +76,18 @@ class ConnectionToBackendMonitorThread(Thread):
         self.max_buffered_packets = max_buffered_packets
         self.max_delay_without_publish = max_delay_without_publish
         self.stop_stack = stop_stack
+
+    @staticmethod
+    def is_black_hole_detection_enabled(settings):
+        is_threshold_set = (
+            settings.buffering_max_buffered_packets > 0
+            or settings.buffering_max_delay_without_publish > 0
+        )
+        is_relevant_action = (
+            settings.buffering_action == BufferingAction.RAISE_SINK_COST
+            or settings.buffering_action == BufferingAction.STOP_STACK
+        )
+        return is_threshold_set and is_relevant_action
 
     def _stop_sinks(self):
         for sink in self.sink_manager.get_sinks():
@@ -163,8 +176,8 @@ class ConnectionToBackendMonitorThread(Thread):
         Args:
             name: name of sink to initialize
         """
-        # It is only required if black hole is managed by sink cost
-        if not self.stop_stack:
+        # It is only required if black hole is managed by sink cost.
+        if self.buffering_action == BufferingAction.RAISE_SINK_COST:
             sink = self.sink_manager.get_sink(name)
 
             logging.info("Initialize sinkCost of sink %s", name)
@@ -433,14 +446,15 @@ class TransportService(BusClient):
         self.minimum_sink_cost = settings.buffering_minimal_sink_cost
         self.sink_manager.set_sink_costs(self.minimum_sink_cost)
 
-        if settings.buffering_max_buffered_packets > 0 or settings.buffering_max_delay_without_publish > 0:
+        if ConnectionToBackendMonitorThread.is_black_hole_detection_enabled(settings):
+            stop_stack = settings.buffering_action == BufferingAction.STOP_STACK
             logging.info(
-                " Black hole detection enabled: max_packets=%s packets, max_delay=%s, stop_stack=%s",
-                settings.buffering_max_buffered_packets,
-                settings.buffering_max_delay_without_publish,
-                settings.buffering_stop_stack
+                "Black hole detection enabled:"
+                f"max_packets={settings.buffering_max_buffered_packets}, "
+                f"max_delay={settings.buffering_max_delay_without_publish}, "
+                f"stop_stack={stop_stack}"
             )
-            # Create and start a monitoring thread for black hole issue
+            # Create and start a monitoring thread for the buffering limitation
             self.monitoring_thread = ConnectionToBackendMonitorThread(
                 self.MONITORING_BUFFERING_PERIOD_S,
                 self.mqtt_wrapper,
@@ -448,7 +462,7 @@ class TransportService(BusClient):
                 settings.buffering_minimal_sink_cost,
                 settings.buffering_max_buffered_packets,
                 settings.buffering_max_delay_without_publish,
-                settings.buffering_stop_stack
+                stop_stack
             )
             self.monitoring_thread.start()
 
@@ -1231,6 +1245,20 @@ def _update_parameters(settings):
             logging.error("Wrong format for whitened_endpoints_filter EP list (%s)", e)
             exit()
 
+    if settings.buffering_stop_stack is not None:
+        logging.warning("Param buffering_stop_stack is deprecated, please use buffering_action instead")
+        if settings.buffering_action is not None:
+            logging.error("Param buffering_stop_stack and buffering_action cannot be set at the same time")
+            exit()
+
+    # Default buffering_action is RAISE_SINK_COST. If not set, it might be
+    # changed by the deprecated buffering_stop_stack parameter.
+    if settings.buffering_action is None:
+        if settings.buffering_stop_stack:
+            settings.buffering_action = BufferingAction.STOP_STACK
+        else:
+            settings.buffering_action = BufferingAction.RAISE_SINK_COST
+
 
 def _check_parameters(settings):
     if settings.mqtt_force_unsecure and settings.mqtt_certfile:
@@ -1248,6 +1276,12 @@ def _check_parameters(settings):
     except TypeError:
         # One of the filter list is None
         pass
+
+    if settings.buffering_action == BufferingAction.DROP_PACKETS and \
+            settings.buffering_max_delay_without_publish != 0:
+        logging.error("Parameter buffering_max_delay_without_publish "
+                      "cannot be used together with buffering_action DROP_PACKETS")
+        exit()
 
 
 def main():

--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -177,7 +177,7 @@ class ConnectionToBackendMonitorThread(Thread):
             name: name of sink to initialize
         """
         # It is only required if black hole is managed by sink cost.
-        if self.buffering_action == BufferingAction.RAISE_SINK_COST:
+        if not self.stop_stack:
             sink = self.sink_manager.get_sink(name)
 
             logging.info("Initialize sinkCost of sink %s", name)

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -13,6 +13,7 @@ import argparse
 import sys
 import os
 import yaml
+from enum import Enum
 
 from .serialization_tools import serialize
 
@@ -30,6 +31,15 @@ class Settings:
 
     def __str__(self):
         return str(self.__dict__)
+
+
+class BufferingAction(Enum):
+    RAISE_SINK_COST = "raise_sink_cost"
+    STOP_STACK = "stop_stack"
+    DROP_PACKETS = "drop_packets"
+
+    def __str__(self):
+        return self.value
 
 
 class ParserHelper:
@@ -384,7 +394,7 @@ class ParserHelper:
             type=self.str2int,
             help=(
                 "Maximum number of messages to buffer before "
-                "rising sink cost (0 will disable feature)"
+                "taking an action (see --buffering_action). 0 will disable feature"
             ),
         )
 
@@ -396,17 +406,21 @@ class ParserHelper:
             help=(
                 "Maximum time to wait in seconds without any "
                 "successful publish with packet queued "
-                "before rising sink cost (0 will disable feature)"
+                "before taking an action (see --buffering_action). 0 will disable feature"
             ),
         )
 
         self.buffering.add_argument(
-            "--buffering_stop_stack",
-            default=os.environ.get("WM_GW_BUFFERING_STOP_STACK", False),
-            type=self.str2bool,
+            "--buffering_action",
+            default=os.environ.get("WM_GW_BUFFERING_ACTION", None),
+            type=BufferingAction,
+            choices=list(BufferingAction),
             help=(
-                "When true, when a black hole is detected, stack is stopped instead of "
-                " increasing the sink cost"
+                "Action to take when the buffer limit is reached. "
+                "'raise_sink_cost': Increases the sink cost. "
+                "'stop_stack': Stops the sink stack. "
+                "'drop_packets': Limits the publish queue size to "
+                "buffering_max_buffered_packets and drops the oldest packets if necessary."
             ),
         )
 
@@ -507,6 +521,13 @@ class ParserHelper:
             default=None,
             type=self.str2none,
             help=ParserHelper._deprecated_message("gateway_id"),
+        )
+
+        self.deprecated.add_argument(
+            "--buffering_stop_stack",
+            default=os.environ.get("WM_GW_BUFFERING_STOP_STACK", None),
+            type=self.str2bool,
+            help=ParserHelper._deprecated_message("buffering_stop_stack"),
         )
 
     def add_gateway_config(self):


### PR DESCRIPTION
See individual commit messages for more details.

Briefly:
- Deprecated WM_GW_BUFFERING_STOP_STACK parameter, it is replaced by WM_GW_BUFFERING_ACTION
- Added new buffering action to drop packets. If MQTT connection is lost, the sink is not modified and the size of the internal queue is limited.