### PR TITLE
Update c-mesh-api for linux serial updates

### DIFF
--- a/sink_service/CMakeLists.txt
+++ b/sink_service/CMakeLists.txt
@@ -12,7 +12,7 @@ add_compile_options(-Wall -Werror -Wextra -Wno-unused-parameter)
 
 set(SINK_SERVICE_VERSION "<unknown>" CACHE STRING "Sink service version string")
 
-set(C_MESH_API_COMMIT_HASH b70b379c8bb4f44b151f99d0af321abe84b63455)
+set(C_MESH_API_COMMIT_HASH 8ff812452b50ee962f16f55fedf386da8797e380)
 
 include(FetchContent)
 FetchContent_Declare(

--- a/sink_service/README.md
+++ b/sink_service/README.md
@@ -27,4 +27,12 @@ cmake --build build
 ```
 Built sinkService will be generated under build/ folder. 
 
+### Using a local copy of c-mesh-api for development purposes
+
+To use a local copy of the c-mesh-api dependency, the cmake command can be
+invoked like the following:
+
+```shell
+cmake -DFETCHCONTENT_SOURCE_DIR_C-MESH-API=<path_to_c-mesh-api> -S . -B build
+```
 


### PR DESCRIPTION
Mainly to get [these](https://github.com/wirepas/c-mesh-api/pull/156) changes. Should help with preventing potential deadlocks.