### PR TITLE
Improve transport service documentation

### DIFF
--- a/python_transport/tests/test_arguments.py
+++ b/python_transport/tests/test_arguments.py
@@ -17,7 +17,6 @@ env_vars["WM_SERVICES_MQTT_CIPHERS"] = "path/mqtt_ciphers"
 # FALSE, means that we don't set it
 env_vars["WM_SERVICES_MQTT_PERSIST_SESSION"] = True
 env_vars["WM_SERVICES_MQTT_FORCE_UNSECURE"] = True
-env_vars["WM_SERVICES_MQTT_ALLOW_UNTRUSTED"] = True
 
 env_vars["WM_GW_BUFFERING_MAX_BUFFERED_PACKETS"] = 1000
 env_vars["WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH"] = 128
@@ -45,7 +44,6 @@ file_vars["mqtt_certfile"] = env_vars["WM_SERVICES_MQTT_CLIENT_CRT"]
 file_vars["mqtt_ciphers"] = env_vars["WM_SERVICES_MQTT_CIPHERS"]
 file_vars["mqtt_persist_session"] = env_vars["WM_SERVICES_MQTT_PERSIST_SESSION"]
 file_vars["mqtt_force_unsecure"] = env_vars["WM_SERVICES_MQTT_FORCE_UNSECURE"]
-file_vars["mqtt_allow_untrusted"] = env_vars["WM_SERVICES_MQTT_ALLOW_UNTRUSTED"]
 file_vars["mqtt_reconnect_delay"] = env_vars["WM_SERVICES_MQTT_RECONNECT_DELAY"]
 file_vars["buffering_max_buffered_packets"] = env_vars[
     "WM_GW_BUFFERING_MAX_BUFFERED_PACKETS"
@@ -64,7 +62,6 @@ file_vars["whitened_endpoints_filter"] = env_vars["WM_GW_WHITENED_ENDPOINTS_FILT
 booleans = [
     "WM_SERVICES_MQTT_PERSIST_SESSION",
     "WM_SERVICES_MQTT_FORCE_UNSECURE",
-    "WM_SERVICES_MQTT_ALLOW_UNTRUSTED",
 ]
 
 
@@ -132,13 +129,6 @@ def content_tests(settings, vcopy):
     else:
         assert vcopy["WM_SERVICES_MQTT_FORCE_UNSECURE"] == settings.mqtt_force_unsecure
 
-    if "WM_SERVICES_MQTT_ALLOW_UNTRUSTED" not in vcopy:
-        assert settings.mqtt_allow_untrusted is False
-    else:
-        assert (
-            vcopy["WM_SERVICES_MQTT_ALLOW_UNTRUSTED"] == settings.mqtt_allow_untrusted
-        )
-
     assert vcopy["WM_SERVICES_MQTT_RECONNECT_DELAY"] == settings.mqtt_reconnect_delay
     assert (
         vcopy["WM_GW_BUFFERING_MAX_BUFFERED_PACKETS"]
@@ -198,7 +188,6 @@ def test_defaults():
     assert settings.mqtt_ciphers is None
     assert settings.mqtt_persist_session is False
     assert settings.mqtt_force_unsecure is False
-    assert settings.mqtt_allow_untrusted is False
     assert settings.mqtt_reconnect_delay == 0
     assert settings.buffering_max_buffered_packets == 0
     assert settings.buffering_max_delay_without_publish == 0

--- a/python_transport/wirepas_gateway/dbus/dbus_client.py
+++ b/python_transport/wirepas_gateway/dbus/dbus_client.py
@@ -5,7 +5,6 @@
 import logging
 from threading import Thread
 from pydbus import SystemBus
-import dbusCExtension
 from gi.repository import GLib, GObject
 from .sink_manager import SinkManager
 
@@ -24,8 +23,12 @@ class DbusEventHandler(Thread):
         """
         Thread.__init__(self)
 
-
-        dbusCExtension.setCallback(cb)
+        # Imported here instead of module level because importing the C
+        # extension requires a running system bus. This allows running "--help"
+        # without connecting to a dbus daemon.
+        import dbusCExtension
+        self._dbus_c_extension = dbusCExtension
+        self._dbus_c_extension.setCallback(cb)
         self.daemon = True  # Daemonize thread
 
     def run(self) -> None:
@@ -34,7 +37,7 @@ class DbusEventHandler(Thread):
         :return: None, as it is an infinite loop in C
         """
         while True:
-            dbusCExtension.infiniteEventLoop()
+            self._dbus_c_extension.infiniteEventLoop()
             logging.error("C extension loop has exited")
 
 

--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -1245,6 +1245,9 @@ def _update_parameters(settings):
             logging.error("Wrong format for whitened_endpoints_filter EP list (%s)", e)
             exit()
 
+    if settings.mqtt_allow_untrusted:
+        logging.warning("Param mqtt_allow_untrusted is deprecated and is not in use.")
+
     if settings.buffering_stop_stack is not None:
         logging.warning("Param buffering_stop_stack is deprecated, please use buffering_action instead")
         if settings.buffering_action is not None:

--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -10,6 +10,7 @@ from time import time, sleep
 from uuid import getnode
 from threading import Thread, Event
 from copy import deepcopy
+import textwrap
 
 from wirepas_gateway.dbus.dbus_client import BusClient
 from wirepas_gateway.protocol.topic_helper import TopicGenerator, TopicParser
@@ -1293,8 +1294,14 @@ def main():
 
     """
     parse = ParserHelper(
-        description="Wirepas Gateway Transport service arguments",
         version=transport_version,
+        description=textwrap.dedent("""\
+        Wirepas Gateway Transport Service
+
+        Each parameter below can also be set with the environment variable
+        shown next to it (i.e. $WM_GW_ID). A parameter given on the command
+        line overrides the environment variable.
+        """)
     )
 
     parse.add_file_settings()

--- a/python_transport/wirepas_gateway/transport_service.py
+++ b/python_transport/wirepas_gateway/transport_service.py
@@ -1314,8 +1314,7 @@ def main():
 
     settings = parse.settings()
 
-    # Set default debug level
-    debug_level = "info"
+    debug_level = settings.log_level
     try:
         debug_level = os.environ["DEBUG_LEVEL"]
         print(
@@ -1323,11 +1322,6 @@ def main():
             "(it will be dropped from version 2.x onwards)"
             " please use WM_DEBUG_LEVEL instead."
         )
-    except KeyError:
-        pass
-
-    try:
-        debug_level = os.environ["WM_DEBUG_LEVEL"]
     except KeyError:
         pass
 

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -222,7 +222,7 @@ class ParserHelper:
         kwargs["metavar"] = "$" + env_variable
         group.add_argument(*args, **kwargs)
 
-    def add_wrapped_description(self, target, description, indentation = 2):
+    def add_wrapped_description(self, target, description, indentation=2):
         """
         Wraps the given description to fit the terminal while keeping line
         beaks and adds it to the given target (for example argument group).
@@ -444,10 +444,11 @@ class ParserHelper:
             action="store",
             type=self.str2int,
             help=(
-                "Max rate limit for the mqtt client to publish on mqtt broker. It can be set to "
-                "protect the broker from very high usage when one or more gateways are offline for a while "
-                "and publish all their buffers when connection to broker is restored. "
-                "0 to disable the limit."
+                "Max rate limit for the mqtt client to publish on mqtt broker. "
+                "It can be set to protect the broker from very high usage "
+                "when one or more gateways are offline for a while and "
+                " publish all their buffers when connection to broker is "
+                "restored. 0 to disable the limit."
             ),
         )
 
@@ -735,8 +736,11 @@ class ParserHelper:
             "--gateway_max_scratchpad_size",
             type=self.str2int,
             default=None,
-            help=("Maximum scratchpad size a gateway can accept. If scratchpad is bigger "
-                  "it must be sent as chunks smaller or equal to this value"),
+            help=(
+                "Maximum scratchpad size a gateway can accept. If scratchpad "
+                "is bigger it must be sent as chunks smaller or equal to "
+                "this value"
+            ),
         )
 
     def add_filtering_config(self):

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -562,6 +562,20 @@ class ParserHelper:
     def add_debug_settings(self):
         self.add_env_argument(
             self.debug,
+            "WM_DEBUG_LEVEL",
+            "--log_level",
+            default="info",
+            type=str,
+            choices=["debug", "info", "warning", "error", "critical"],
+            help=(
+                "Log level of the transport service. 'debug' level might "
+                "generate too much logs and is not recommended to be used in a "
+                "production system."
+            ),
+        )
+
+        self.add_env_argument(
+            self.debug,
             "WM_SERVICES_DEBUG_INCR_EVENT_ID",
             "--debug_incr_data_event_id",
             default=False,

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -13,6 +13,8 @@ import argparse
 import sys
 import os
 import yaml
+import textwrap
+import shutil
 from enum import Enum
 
 from .serialization_tools import serialize
@@ -219,6 +221,22 @@ class ParserHelper:
         kwargs["help"] = " ".join(help_text)
         kwargs["metavar"] = "$" + env_variable
         group.add_argument(*args, **kwargs)
+
+    def add_wrapped_description(self, target, description, indentation = 2):
+        """
+        Wraps the given description to fit the terminal while keeping line
+        beaks and adds it to the given target (for example argument group).
+        """
+        width = shutil.get_terminal_size().columns - indentation
+        lines = []
+        for paragraph in description.splitlines():
+            if not paragraph:
+                lines.append("")
+                continue
+            wrapped = textwrap.wrap(paragraph, width, replace_whitespace=False)
+            lines.extend(wrapped)
+
+        target.description = "\n".join(lines)
 
     def add_file_settings(self):
         """ For file setting handling"""
@@ -448,6 +466,57 @@ class ParserHelper:
 
     def add_buffering_settings(self):
         """ Parameters used to avoid black hole case """
+        self.add_wrapped_description(
+            self.buffering,
+            textwrap.dedent("""\
+            If the MQTT connection is lost, transport service might end up
+            buffering uplink packets and never send them to the MQTT broker,
+            becoming a "black hole".
+
+            Transport service can be configured to detect this and avoid it in
+            different ways, which can be selected by WM_GW_BUFFERING_ACTION
+            parameter. By default, transport service will buffer outgoing MQTT
+            messages without any limit and retry connecting to the broker.
+
+            The black hole prevention can be enabled by setting
+            WM_GW_BUFFERING_MAX_BUFFERED_PACKETS or
+            WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH parameter.
+
+            Different actions are described below:
+
+            * 'raise_sink_cost'
+              Sink costs of sinks connected to this gateway are raised to
+              discourage nodes from connecting to sinks under this gateway.
+
+            * 'stop_stack'
+              Sinks connected to this gateway are stopped to ensure nodes are
+              not connected to sinks under this gateway.
+
+            * 'drop_packets'
+              Enabled only by WM_GW_BUFFERING_MAX_BUFFERED_PACKETS;
+              WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH cannot be used with
+              this action. Internal publish queue size is limited to
+              WM_GW_BUFFERING_MAX_BUFFERED_PACKETS and the oldest MQTT messages
+              are dropped if necessary. Drops are reported in the log
+              periodically.
+
+            Once the MQTT connection is reestablished, the transport service
+            waits until all buffered messages have been successfully published
+            before lowering sink costs or starting sinks again. This is done to
+            prevent modifying sink parameters in unstable connections with
+            intermittent disconnects. Also see the WM_SERVICES_MQTT_RATE_LIMIT_PPS
+            parameter.
+
+            When lowering sink costs, the value of
+            WM_GW_BUFFERING_MINIMAL_SINK_COST is used. It is also applied to
+            sinks at startup, even when black hole prevention is disabled:
+            unlike most sink configuration parameters, sink cost cannot be set
+            over the MQTT interface, so a raised cost left behind by an earlier
+            gateway configuration could not be lowered by the backend
+            otherwise.
+            """),
+        )
+
         self.add_env_argument(
             self.buffering,
             "WM_GW_BUFFERING_MAX_BUFFERED_PACKETS",
@@ -457,7 +526,7 @@ class ParserHelper:
             type=self.str2int,
             help=(
                 "Maximum number of messages to buffer before "
-                "taking an action (see --buffering_action). 0 will disable feature"
+                "taking an action. 0 will disable feature"
             ),
         )
 
@@ -471,7 +540,7 @@ class ParserHelper:
             help=(
                 "Maximum time to wait in seconds without any "
                 "successful publish with packet queued "
-                "before taking an action (see --buffering_action). 0 will disable feature"
+                "before taking an action. 0 will disable feature"
             ),
         )
 
@@ -482,12 +551,8 @@ class ParserHelper:
             default=None,
             type=BufferingAction,
             choices=list(BufferingAction),
-            help=(
-                "Action to take when the buffer limit is reached. "
-                "'raise_sink_cost': Increases the sink cost. "
-                "'stop_stack': Stops the sink stack. "
-                "'drop_packets': Limits the publish queue size to "
-                "buffering_max_buffered_packets and drops the oldest packets if necessary."
+            help=("Action to take when the buffer limit is reached. "
+                  "When empty, it is assumed to be 'raise_sink_cost'."
             ),
         )
 

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -726,6 +726,21 @@ class ParserHelper:
         )
 
     def add_filtering_config(self):
+        self.add_wrapped_description(
+            self.filtering,
+            textwrap.dedent("""\
+            Filters to limit which packets received from the Wirepas
+            network are published to the MQTT broker. Both filters apply
+            to uplink traffic only and select packets based on their
+            destination endpoint. Downlink traffic is never filtered.
+
+            Both parameters accept a list of endpoints (i.e. [1,2,3]), a
+            range of endpoints (i.e. [1-3]), or a combination of both
+            (i.e. [1,2,10-15]). Valid endpoint values are 0-255. An
+            endpoint cannot be in both lists at the same time.
+            """),
+        )
+
         self.add_env_argument(
             self.filtering,
             "WM_GW_IGNORED_ENDPOINTS_FILTER",
@@ -733,7 +748,10 @@ class ParserHelper:
             "--ignored_endpoints_filter",
             type=self.str2none,
             default=None,
-            help=("Destination endpoints list to ignore (not published)."),
+            help=(
+                "Destination endpoints list to ignore. Packets sent to "
+                "these endpoints are not published at all."
+            ),
         )
 
         self.add_env_argument(
@@ -744,8 +762,9 @@ class ParserHelper:
             type=self.str2none,
             default=None,
             help=(
-                "Destination endpoints list to whiten "
-                "(no payload content, only size)."
+                "Destination endpoints list to whiten (i.e. blank out the "
+                "payload). Packets sent to these endpoints are published "
+                "without the payload content, only the payload size is kept."
             ),
         )
 

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -70,7 +70,7 @@ class ParserHelper:
     def __init__(
         self,
         description="argument parser",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         version=None,
     ):
         super(ParserHelper, self).__init__()
@@ -195,53 +195,90 @@ class ParserHelper:
             return None
         return value
 
+    def add_env_argument(self,
+                         group,
+                         env_variable,
+                         *args,
+                         **kwargs):
+        """
+        Wrapper for adding an argument which can be set with an environment
+        variable. Arbitrary arguments are passed to argparse.
+        """
+        default = kwargs.get("default")
+        kwargs["default"] = os.environ.get(env_variable, default)
+
+        help_text = []
+        if "help" in kwargs:
+            help_text.append(kwargs["help"])
+        if "choices" in kwargs:
+            choice_strs = [str(choice) for choice in kwargs["choices"]]
+            result = '[%s]' % ', '.join(choice_strs)
+            help_text.append(f"(choices: {result})")
+        help_text.append(f"(default: {default})")
+
+        kwargs["help"] = " ".join(help_text)
+        kwargs["metavar"] = "$" + env_variable
+        group.add_argument(*args, **kwargs)
+
     def add_file_settings(self):
         """ For file setting handling"""
-        self.file_settings.add_argument(
+        self.add_env_argument(
+            self.file_settings,
+            "WM_GW_FILE_SETTINGS",
             "--settings",
             type=self.str2none,
             required=False,
-            default=os.environ.get("WM_GW_FILE_SETTINGS", None),
+            default=None,
             help="A yaml file with argument parameters (see help for options).",
         )
 
     def add_mqtt(self):
         """ Commonly used MQTT arguments """
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_HOSTNAME",
             "--mqtt_hostname",
-            default=os.environ.get("WM_SERVICES_MQTT_HOSTNAME", None),
+            default=None,
             action="store",
             type=self.str2none,
             help="MQTT broker hostname.",
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_USERNAME",
             "--mqtt_username",
-            default=os.environ.get("WM_SERVICES_MQTT_USERNAME", None),
+            default=None,
             action="store",
             type=self.str2none,
             help="MQTT broker username.",
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_PASSWORD",
             "--mqtt_password",
-            default=os.environ.get("WM_SERVICES_MQTT_PASSWORD", None),
+            default=None,
             action="store",
             type=self.str2none,
             help="MQTT broker password.",
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_PORT",
             "--mqtt_port",
-            default=os.environ.get("WM_SERVICES_MQTT_PORT", 8883),
+            default=8883,
             action="store",
             type=self.str2int,
             help="MQTT broker port.",
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_CA_CERTS",
             "--mqtt_ca_certs",
-            default=os.environ.get("WM_SERVICES_MQTT_CA_CERTS", None),
+            default=None,
             action="store",
             type=self.str2none,
             help=(
@@ -252,17 +289,21 @@ class ParserHelper:
             ),
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_CLIENT_CRT",
             "--mqtt_certfile",
-            default=os.environ.get("WM_SERVICES_MQTT_CLIENT_CRT", None),
+            default=None,
             action="store",
             type=self.str2none,
             help=("Path to the PEM encoded client certificate."),
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_CLIENT_KEY",
             "--mqtt_keyfile",
-            default=os.environ.get("WM_SERVICES_MQTT_CLIENT_KEY", None),
+            default=None,
             action="store",
             type=self.str2none,
             help=(
@@ -272,9 +313,11 @@ class ParserHelper:
             ),
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_CERT_REQS",
             "--mqtt_cert_reqs",
-            default=os.environ.get("WM_SERVICES_MQTT_CERT_REQS", "CERT_REQUIRED"),
+            default="CERT_REQUIRED",
             choices=["CERT_REQUIRED", "CERT_OPTIONAL", "CERT_NONE"],
             action="store",
             type=self.str2none,
@@ -285,9 +328,11 @@ class ParserHelper:
             ),
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_TLS_VERSION",
             "--mqtt_tls_version",
-            default=os.environ.get("WM_SERVICES_MQTT_TLS_VERSION", "PROTOCOL_TLSv1_2"),
+            default="PROTOCOL_TLSv1_2",
             choices=[
                 "PROTOCOL_TLS",
                 "PROTOCOL_TLS_CLIENT",
@@ -301,9 +346,11 @@ class ParserHelper:
             help=("Specifies the version of the SSL / TLS protocol to be used."),
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_CIPHERS",
             "--mqtt_ciphers",
-            default=os.environ.get("WM_SERVICES_MQTT_CIPHERS", None),
+            default=None,
             action="store",
             type=self.str2none,
             help=(
@@ -313,9 +360,11 @@ class ParserHelper:
             ),
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_PERSIST_SESSION",
             "--mqtt_persist_session",
-            default=os.environ.get("WM_SERVICES_MQTT_PERSIST_SESSION", False),
+            default=False,
             type=self.str2bool,
             nargs="?",
             const=True,
@@ -325,27 +374,33 @@ class ParserHelper:
             ),
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_FORCE_UNSECURE",
             "--mqtt_force_unsecure",
-            default=os.environ.get("WM_SERVICES_MQTT_FORCE_UNSECURE", False),
+            default=False,
             type=self.str2bool,
             nargs="?",
             const=True,
             help=("When True the broker will skip the TLS handshake."),
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_ALLOW_UNTRUSTED",
             "--mqtt_allow_untrusted",
-            default=os.environ.get("WM_SERVICES_MQTT_ALLOW_UNTRUSTED", False),
+            default=False,
             type=self.str2bool,
             nargs="?",
             const=True,
             help=("When true the client will skip the certificate name check."),
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_RECONNECT_DELAY",
             "--mqtt_reconnect_delay",
-            default=os.environ.get("WM_SERVICES_MQTT_RECONNECT_DELAY", 0),
+            default=0,
             action="store",
             type=self.str2int,
             help=(
@@ -354,17 +409,21 @@ class ParserHelper:
             ),
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_MAX_INFLIGHT_MESSAGES",
             "--mqtt_max_inflight_messages",
-            default=os.environ.get("WM_SERVICES_MQTT_MAX_INFLIGHT_MESSAGES", 20),
+            default=20,
             action="store",
             type=self.str2int,
             help=("Max inflight messages for messages with qos > 0"),
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_USE_WEBSOCKET",
             "--mqtt_use_websocket",
-            default=os.environ.get("WM_SERVICES_MQTT_USE_WEBSOCKET", False),
+            default=False,
             type=self.str2bool,
             nargs="?",
             const=True,
@@ -373,9 +432,11 @@ class ParserHelper:
             ),
         )
 
-        self.mqtt.add_argument(
+        self.add_env_argument(
+            self.mqtt,
+            "WM_SERVICES_MQTT_RATE_LIMIT_PPS",
             "--mqtt_rate_limit_pps",
-            default=os.environ.get("WM_SERVICES_MQTT_RATE_LIMIT_PPS", 0),
+            default=0,
             action="store",
             type=self.str2int,
             help=(
@@ -387,9 +448,11 @@ class ParserHelper:
 
     def add_buffering_settings(self):
         """ Parameters used to avoid black hole case """
-        self.buffering.add_argument(
+        self.add_env_argument(
+            self.buffering,
+            "WM_GW_BUFFERING_MAX_BUFFERED_PACKETS",
             "--buffering_max_buffered_packets",
-            default=os.environ.get("WM_GW_BUFFERING_MAX_BUFFERED_PACKETS", 0),
+            default=0,
             action="store",
             type=self.str2int,
             help=(
@@ -398,9 +461,11 @@ class ParserHelper:
             ),
         )
 
-        self.buffering.add_argument(
+        self.add_env_argument(
+            self.buffering,
+            "WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH",
             "--buffering_max_delay_without_publish",
-            default=os.environ.get("WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH", 0),
+            default=0,
             action="store",
             type=self.str2int,
             help=(
@@ -410,9 +475,11 @@ class ParserHelper:
             ),
         )
 
-        self.buffering.add_argument(
+        self.add_env_argument(
+            self.buffering,
+            "WM_GW_BUFFERING_ACTION",
             "--buffering_action",
-            default=os.environ.get("WM_GW_BUFFERING_ACTION", None),
+            default=None,
             type=BufferingAction,
             choices=list(BufferingAction),
             help=(
@@ -426,9 +493,11 @@ class ParserHelper:
 
         # This minimal sink cost could be moved somewhere as it can be used even
         # buffering limitation is not in use
-        self.buffering.add_argument(
+        self.add_env_argument(
+            self.buffering,
+            "WM_GW_BUFFERING_MINIMAL_SINK_COST",
             "--buffering_minimal_sink_cost",
-            default=os.environ.get("WM_GW_BUFFERING_MINIMAL_SINK_COST", 0),
+            default=0,
             action="store",
             type=self.str2int,
             help=(
@@ -439,9 +508,11 @@ class ParserHelper:
         )
 
     def add_debug_settings(self):
-        self.debug.add_argument(
+        self.add_env_argument(
+            self.debug,
+            "WM_SERVICES_DEBUG_INCR_EVENT_ID",
             "--debug_incr_data_event_id",
-            default=os.environ.get("WM_SERVICES_DEBUG_INCR_EVENT_ID", False),
+            default=False,
             type=self.str2bool,
             nargs="?",
             const=True,
@@ -523,17 +594,21 @@ class ParserHelper:
             help=ParserHelper._deprecated_message("gateway_id"),
         )
 
-        self.deprecated.add_argument(
+        self.add_env_argument(
+            self.deprecated,
+            "WM_GW_BUFFERING_STOP_STACK",
             "--buffering_stop_stack",
-            default=os.environ.get("WM_GW_BUFFERING_STOP_STACK", None),
+            default=None,
             type=self.str2bool,
-            help=ParserHelper._deprecated_message("buffering_stop_stack"),
+            help=ParserHelper._deprecated_message("buffering_action"),
         )
 
     def add_gateway_config(self):
-        self.gateway.add_argument(
+        self.add_env_argument(
+            self.gateway,
+            "WM_GW_ID",
             "--gateway_id",
-            default=os.environ.get("WM_GW_ID", None),
+            default=None,
             type=self.str2none,
             help=("Id of the gateway. It must be unique on same broker."),
         )
@@ -548,45 +623,55 @@ class ParserHelper:
             help=("Do not use C extension for optimization."),
         )
 
-        self.gateway.add_argument(
+        self.add_env_argument(
+            self.gateway,
+            "WM_GW_MODEL",
             "-gm",
             "--gateway_model",
             type=self.str2none,
-            default=os.environ.get("WM_GW_MODEL", None),
+            default=None,
             help=("Model name of the gateway."),
         )
 
-        self.gateway.add_argument(
+        self.add_env_argument(
+            self.gateway,
+            "WM_GW_VERSION",
             "-gv",
             "--gateway_version",
             type=self.str2none,
-            default=os.environ.get("WM_GW_VERSION", None),
+            default=None,
             help=("Version of the gateway."),
         )
 
-        self.gateway.add_argument(
+        self.add_env_argument(
+            self.gateway,
+            "WM_GW_MAX_SCRAT_SIZE",
             "-gmss",
             "--gateway_max_scratchpad_size",
             type=self.str2int,
-            default=os.environ.get("WM_GW_MAX_SCRAT_SIZE", None),
+            default=None,
             help=("Maximum scratchpad size a gateway can accept. If scratchpad is bigger"
                   "it must be sent as chunks smaller or equal to this value"),
         )
 
     def add_filtering_config(self):
-        self.filtering.add_argument(
+        self.add_env_argument(
+            self.filtering,
+            "WM_GW_IGNORED_ENDPOINTS_FILTER",
             "-iepf",
             "--ignored_endpoints_filter",
             type=self.str2none,
-            default=os.environ.get("WM_GW_IGNORED_ENDPOINTS_FILTER", None),
+            default=None,
             help=("Destination endpoints list to ignore (not published)."),
         )
 
-        self.filtering.add_argument(
+        self.add_env_argument(
+            self.filtering,
+            "WM_GW_WHITENED_ENDPOINTS_FILTER",
             "-wepf",
             "--whitened_endpoints_filter",
             type=self.str2none,
-            default=os.environ.get("WM_GW_WHITENED_ENDPOINTS_FILTER", None),
+            default=None,
             help=(
                 "Destination endpoints list to whiten "
                 "(no payload content, only size)."

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -401,17 +401,6 @@ class ParserHelper:
 
         self.add_env_argument(
             self.mqtt,
-            "WM_SERVICES_MQTT_ALLOW_UNTRUSTED",
-            "--mqtt_allow_untrusted",
-            default=False,
-            type=self.str2bool,
-            nargs="?",
-            const=True,
-            help=("When true the client will skip the certificate name check."),
-        )
-
-        self.add_env_argument(
-            self.mqtt,
             "WM_SERVICES_MQTT_RECONNECT_DELAY",
             "--mqtt_reconnect_delay",
             default=0,
@@ -587,14 +576,16 @@ class ParserHelper:
         )
 
     @staticmethod
-    def _deprecated_message(new_arg_name, deprecated_from="2.x"):
+    def _deprecated_message(new_arg_name="", deprecated_from="2.x"):
         """ Alerts the user that an argument will be deprecated within the
         next release version
         """
         msg = (
             "Deprecated argument (it will be dropped "
-            "from version {} onwards) please use --{} instead."
-        ).format(deprecated_from, new_arg_name)
+            f"from version {deprecated_from} onwards)"
+        )
+        if new_arg_name:
+            msg += f" please use --{new_arg_name} instead."
         return msg
 
     def add_deprecated_args(self):
@@ -655,6 +646,17 @@ class ParserHelper:
             default=None,
             type=self.str2none,
             help=ParserHelper._deprecated_message("gateway_id"),
+        )
+
+        self.add_env_argument(
+            self.deprecated,
+            "WM_SERVICES_MQTT_ALLOW_UNTRUSTED",
+            "--mqtt_allow_untrusted",
+            default=False,
+            type=self.str2bool,
+            nargs="?",
+            const=True,
+            help="Not in use. " + ParserHelper._deprecated_message(),
         )
 
         self.add_env_argument(

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -675,7 +675,13 @@ class ParserHelper:
             "--gateway_id",
             default=None,
             type=self.str2none,
-            help=("Id of the gateway. It must be unique on same broker."),
+            help=(
+                "Id of the gateway. It must be unique on same broker. "
+                "When empty, an id is generated based on the network "
+                "interface MAC address (uuid.getnode()). The id is used "
+                "in MQTT topics without escaping, so special MQTT "
+                "characters (+, #, /) should be avoided."
+            ),
         )
 
         self.gateway.add_argument(
@@ -715,7 +721,7 @@ class ParserHelper:
             "--gateway_max_scratchpad_size",
             type=self.str2int,
             default=None,
-            help=("Maximum scratchpad size a gateway can accept. If scratchpad is bigger"
+            help=("Maximum scratchpad size a gateway can accept. If scratchpad is bigger "
                   "it must be sent as chunks smaller or equal to this value"),
         )
 

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -71,14 +71,14 @@ class ParserHelper:
 
     def __init__(
         self,
-        description="argument parser",
+        description=None,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         version=None,
     ):
         super(ParserHelper, self).__init__()
-        self._parser = argparse.ArgumentParser(
-            description=description, formatter_class=formatter_class
-        )
+        self._parser = argparse.ArgumentParser(formatter_class=formatter_class)
+        if description is not None:
+            self.add_wrapped_description(self._parser, description)
 
         self._groups = dict()
         self._unknown_arguments = None

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -324,11 +324,7 @@ class ParserHelper:
             default=None,
             action="store",
             type=self.str2none,
-            help=(
-                "Path to the PEM "
-                "encoded client private keys "
-                "respectively."
-            ),
+            help=("Path to the PEM encoded client private key."),
         )
 
         self.add_env_argument(
@@ -400,7 +396,7 @@ class ParserHelper:
             type=self.str2bool,
             nargs="?",
             const=True,
-            help=("When True the broker will skip the TLS handshake."),
+            help=("When true, connect to the broker without TLS."),
         )
 
         self.add_env_argument(
@@ -422,8 +418,9 @@ class ParserHelper:
             action="store",
             type=self.str2int,
             help=(
-                "Delay in seconds to try to reconnect when connection to"
-                "broker is lost (0 to try forever)"
+                "Time in seconds to keep trying to reconnect when the "
+                "connection to the broker is lost. If it expires, the "
+                "service exits. 0 to retry forever."
             ),
         )
 
@@ -460,7 +457,8 @@ class ParserHelper:
             help=(
                 "Max rate limit for the mqtt client to publish on mqtt broker. It can be set to "
                 "protect the broker from very high usage when one or more gateways are offline for a while "
-                "and publish all their buffers when connection to broker is restored"
+                "and publish all their buffers when connection to broker is restored. "
+                "0 to disable the limit."
             ),
         )
 

--- a/python_transport/wirepas_gateway/utils/argument_tools.py
+++ b/python_transport/wirepas_gateway/utils/argument_tools.py
@@ -192,7 +192,7 @@ class ParserHelper:
 
     @staticmethod
     def str2none(value):
-        """ Ensures string to bool conversion """
+        """ Converts empty strings to None """
         if value == "":
             return None
         return value


### PR DESCRIPTION
Improve argparse parameters so that --help can be used as documentation and source of truth. After this, the table in docker/docker-compose/README.md can be removed and, a new one added in transport service readme based on the help text.

Briefly:
- Feature-level documentation (for example buffering / black hole prevention, filtering)
- Various improvements and fixes to argument help texts
- `docker run wirepas/gateway_transport_service wm-gw --help` should now work
- Deprecate WM_SERVICES_MQTT_ALLOW_UNTRUSTED; it wasn't used before and I think no need to connect it now

<details>
<summary>Example output</summary>

```
Using upb implementation for protobuf
usage: wm-gw [-h] [--version] [--settings $WM_GW_FILE_SETTINGS]
             [--mqtt_hostname $WM_SERVICES_MQTT_HOSTNAME]
             [--mqtt_username $WM_SERVICES_MQTT_USERNAME]
             [--mqtt_password $WM_SERVICES_MQTT_PASSWORD]
             [--mqtt_port $WM_SERVICES_MQTT_PORT]
             [--mqtt_ca_certs $WM_SERVICES_MQTT_CA_CERTS]
             [--mqtt_certfile $WM_SERVICES_MQTT_CLIENT_CRT]
             [--mqtt_keyfile $WM_SERVICES_MQTT_CLIENT_KEY]
             [--mqtt_cert_reqs $WM_SERVICES_MQTT_CERT_REQS]
             [--mqtt_tls_version $WM_SERVICES_MQTT_TLS_VERSION]
             [--mqtt_ciphers $WM_SERVICES_MQTT_CIPHERS]
             [--mqtt_persist_session [$WM_SERVICES_MQTT_PERSIST_SESSION]]
             [--mqtt_force_unsecure [$WM_SERVICES_MQTT_FORCE_UNSECURE]]
             [--mqtt_reconnect_delay $WM_SERVICES_MQTT_RECONNECT_DELAY]
             [--mqtt_max_inflight_messages $WM_SERVICES_MQTT_MAX_INFLIGHT_MESSAGES]
             [--mqtt_use_websocket [$WM_SERVICES_MQTT_USE_WEBSOCKET]]
             [--mqtt_rate_limit_pps $WM_SERVICES_MQTT_RATE_LIMIT_PPS]
             [--gateway_id $WM_GW_ID] [-fp [FULL_PYTHON]] [-gm $WM_GW_MODEL]
             [-gv $WM_GW_VERSION] [-gmss $WM_GW_MAX_SCRAT_SIZE]
             [-iepf $WM_GW_IGNORED_ENDPOINTS_FILTER]
             [-wepf $WM_GW_WHITENED_ENDPOINTS_FILTER]
             [--buffering_max_buffered_packets $WM_GW_BUFFERING_MAX_BUFFERED_PACKETS]
             [--buffering_max_delay_without_publish $WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH]
             [--buffering_action $WM_GW_BUFFERING_ACTION]
             [--buffering_minimal_sink_cost $WM_GW_BUFFERING_MINIMAL_SINK_COST]
             [--log_level $WM_DEBUG_LEVEL]
             [--debug_incr_data_event_id [$WM_SERVICES_DEBUG_INCR_EVENT_ID]]
             [-s HOST] [-p PORT] [-u USERNAME] [-pw PASSWORD] [-t TLSFILE]
             [-ua [UNSECURE_AUTHENTICATION]] [-i GWID]
             [--mqtt_allow_untrusted [$WM_SERVICES_MQTT_ALLOW_UNTRUSTED]]
             [--buffering_stop_stack $WM_GW_BUFFERING_STOP_STACK]

Wirepas Gateway Transport Service

Each parameter below can also be set with the environment variable
shown next to it (i.e. $WM_GW_ID). A parameter given on the command
line overrides the environment variable.

options:
  -h, --help            show this help message and exit

main:
  --version             show program's version number and exit

file_settings:
  --settings $WM_GW_FILE_SETTINGS
                        A yaml file with argument parameters (see help for
                        options). (default: None)

mqtt:
  --mqtt_hostname $WM_SERVICES_MQTT_HOSTNAME
                        MQTT broker hostname. (default: None)
  --mqtt_username $WM_SERVICES_MQTT_USERNAME
                        MQTT broker username. (default: None)
  --mqtt_password $WM_SERVICES_MQTT_PASSWORD
                        MQTT broker password. (default: None)
  --mqtt_port $WM_SERVICES_MQTT_PORT
                        MQTT broker port. (default: 8883)
  --mqtt_ca_certs $WM_SERVICES_MQTT_CA_CERTS
                        Path to the Certificate Authority certificate files
                        that are to be treated as trusted by this client.
                        (default: None)
  --mqtt_certfile $WM_SERVICES_MQTT_CLIENT_CRT
                        Path to the PEM encoded client certificate. (default:
                        None)
  --mqtt_keyfile $WM_SERVICES_MQTT_CLIENT_KEY
                        Path to the PEM encoded client private key. (default:
                        None)
  --mqtt_cert_reqs $WM_SERVICES_MQTT_CERT_REQS
                        Defines the certificate requirements that the client
                        imposes on the broker. (choices: [CERT_REQUIRED,
                        CERT_OPTIONAL, CERT_NONE]) (default: CERT_REQUIRED)
  --mqtt_tls_version $WM_SERVICES_MQTT_TLS_VERSION
                        Specifies the version of the SSL / TLS protocol to be
                        used. (choices: [PROTOCOL_TLS, PROTOCOL_TLS_CLIENT,
                        PROTOCOL_TLS_SERVER, PROTOCOL_TLSv1, PROTOCOL_TLSv1_1,
                        PROTOCOL_TLSv1_2]) (default: PROTOCOL_TLSv1_2)
  --mqtt_ciphers $WM_SERVICES_MQTT_CIPHERS
                        A string specifying which encryption ciphers are
                        allowable for this connection. (default: None)
  --mqtt_persist_session [$WM_SERVICES_MQTT_PERSIST_SESSION]
                        When True the broker will buffer session packets
                        between reconnection. (default: False)
  --mqtt_force_unsecure [$WM_SERVICES_MQTT_FORCE_UNSECURE]
                        When true, connect to the broker without TLS.
                        (default: False)
  --mqtt_reconnect_delay $WM_SERVICES_MQTT_RECONNECT_DELAY
                        Time in seconds to keep trying to reconnect when the
                        connection to the broker is lost. If it expires, the
                        service exits. 0 to retry forever. (default: 0)
  --mqtt_max_inflight_messages $WM_SERVICES_MQTT_MAX_INFLIGHT_MESSAGES
                        Max inflight messages for messages with qos > 0
                        (default: 20)
  --mqtt_use_websocket [$WM_SERVICES_MQTT_USE_WEBSOCKET]
                        When true the mqtt client will use websocket instead
                        of TCP for transport (default: False)
  --mqtt_rate_limit_pps $WM_SERVICES_MQTT_RATE_LIMIT_PPS
                        Max rate limit for the mqtt client to publish on mqtt
                        broker. It can be set to protect the broker from very
                        high usage when one or more gateways are offline for a
                        while and publish all their buffers when connection to
                        broker is restored. 0 to disable the limit. (default:
                        0)

gateway:
  --gateway_id $WM_GW_ID
                        Id of the gateway. It must be unique on same broker.
                        When empty, an id is generated based on the network
                        interface MAC address (uuid.getnode()). The id is used
                        in MQTT topics without escaping, so special MQTT
                        characters (+, #, /) should be avoided. (default:
                        None)
  -fp [FULL_PYTHON], --full_python [FULL_PYTHON]
                        Do not use C extension for optimization.
  -gm $WM_GW_MODEL, --gateway_model $WM_GW_MODEL
                        Model name of the gateway. (default: None)
  -gv $WM_GW_VERSION, --gateway_version $WM_GW_VERSION
                        Version of the gateway. (default: None)
  -gmss $WM_GW_MAX_SCRAT_SIZE, --gateway_max_scratchpad_size $WM_GW_MAX_SCRAT_SIZE
                        Maximum scratchpad size a gateway can accept. If
                        scratchpad is bigger it must be sent as chunks smaller
                        or equal to this value (default: None)

filtering:
  Filters to limit which packets received from the Wirepas
  network are published to the MQTT broker. Both filters apply
  to uplink traffic only and select packets based on their
  destination endpoint. Downlink traffic is never filtered.
  
  Both parameters accept a list of endpoints (i.e. [1,2,3]), a
  range of endpoints (i.e. [1-3]), or a combination of both
  (i.e. [1,2,10-15]). Valid endpoint values are 0-255. An
  endpoint cannot be in both lists at the same time.

  -iepf $WM_GW_IGNORED_ENDPOINTS_FILTER, --ignored_endpoints_filter $WM_GW_IGNORED_ENDPOINTS_FILTER
                        Destination endpoints list to ignore. Packets sent to
                        these endpoints are not published at all. (default:
                        None)
  -wepf $WM_GW_WHITENED_ENDPOINTS_FILTER, --whitened_endpoints_filter $WM_GW_WHITENED_ENDPOINTS_FILTER
                        Destination endpoints list to whiten (i.e. blank out
                        the payload). Packets sent to these endpoints are
                        published without the payload content, only the
                        payload size is kept. (default: None)

buffering:
  If the MQTT connection is lost, transport service might end up
  buffering uplink packets and never send them to the MQTT broker,
  becoming a "black hole".
  
  Transport service can be configured to detect this and avoid it in
  different ways, which can be selected by WM_GW_BUFFERING_ACTION
  parameter. By default, transport service will buffer outgoing MQTT
  messages without any limit and retry connecting to the broker.
  
  The black hole prevention can be enabled by setting
  WM_GW_BUFFERING_MAX_BUFFERED_PACKETS or
  WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH parameter.
  
  Different actions are described below:
  
  * 'raise_sink_cost'
    Sink costs of sinks connected to this gateway are raised to
    discourage nodes from connecting to sinks under this gateway.
  
  * 'stop_stack'
    Sinks connected to this gateway are stopped to ensure nodes are
    not connected to sinks under this gateway.
  
  * 'drop_packets'
    Enabled only by WM_GW_BUFFERING_MAX_BUFFERED_PACKETS;
    WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH cannot be used with
    this action. Internal publish queue size is limited to
    WM_GW_BUFFERING_MAX_BUFFERED_PACKETS and the oldest MQTT messages
    are dropped if necessary. Drops are reported in the log
    periodically.
  
  Once the MQTT connection is reestablished, the transport service
  waits until all buffered messages have been successfully published
  before lowering sink costs or starting sinks again. This is done to
  prevent modifying sink parameters in unstable connections with
  intermittent disconnects. Also see the WM_SERVICES_MQTT_RATE_LIMIT_PPS
  parameter.
  
  When lowering sink costs, the value of
  WM_GW_BUFFERING_MINIMAL_SINK_COST is used. It is also applied to
  sinks at startup, even when black hole prevention is disabled:
  unlike most sink configuration parameters, sink cost cannot be set
  over the MQTT interface, so a raised cost left behind by an earlier
  gateway configuration could not be lowered by the backend
  otherwise.

  --buffering_max_buffered_packets $WM_GW_BUFFERING_MAX_BUFFERED_PACKETS
                        Maximum number of messages to buffer before taking an
                        action. 0 will disable feature (default: 0)
  --buffering_max_delay_without_publish $WM_GW_BUFFERING_MAX_DELAY_WITHOUT_PUBLISH
                        Maximum time to wait in seconds without any successful
                        publish with packet queued before taking an action. 0
                        will disable feature (default: 0)
  --buffering_action $WM_GW_BUFFERING_ACTION
                        Action to take when the buffer limit is reached. When
                        empty, it is assumed to be 'raise_sink_cost'.
                        (choices: [raise_sink_cost, stop_stack, drop_packets])
                        (default: None)
  --buffering_minimal_sink_cost $WM_GW_BUFFERING_MINIMAL_SINK_COST
                        Minimal sink cost for a sink on this gateway. Can be
                        used to minimize traffic on a gateway, but it will
                        reduce maximum number of hops for this gateway
                        (default: 0)

debug:
  --log_level $WM_DEBUG_LEVEL
                        Log level of the transport service. 'debug' level
                        might generate too much logs and is not recommended to
                        be used in a production system. (choices: [debug,
                        info, warning, error, critical]) (default: info)
  --debug_incr_data_event_id [$WM_SERVICES_DEBUG_INCR_EVENT_ID]
                        When true the data received event id will be
                        incremental starting at 0 when service starts.
                        Otherwise it will be random 64 bits id. (default:
                        False)

deprecated:
  -s HOST, --host HOST  Deprecated argument (it will be dropped from version
                        2.x onwards) please use --mqtt_hostname instead.
  -p PORT, --port PORT  Deprecated argument (it will be dropped from version
                        2.x onwards) please use --mqtt_port instead.
  -u USERNAME, --username USERNAME
                        Deprecated argument (it will be dropped from version
                        2.x onwards) please use --mqtt_username instead.
  -pw PASSWORD, --password PASSWORD
                        Deprecated argument (it will be dropped from version
                        2.x onwards) please use --mqtt_password instead.
  -t TLSFILE, --tlsfile TLSFILE
                        Deprecated argument (it will be dropped from version
                        2.x onwards) please use --mqtt_certfile instead.
  -ua [UNSECURE_AUTHENTICATION], --unsecure_authentication [UNSECURE_AUTHENTICATION]
                        Deprecated argument (it will be dropped from version
                        2.x onwards) please use --mqtt_force_unsecure instead.
  -i GWID, --gwid GWID  Deprecated argument (it will be dropped from version
                        2.x onwards) please use --gateway_id instead.
  --mqtt_allow_untrusted [$WM_SERVICES_MQTT_ALLOW_UNTRUSTED]
                        Not in use. Deprecated argument (it will be dropped
                        from version 2.x onwards) (default: False)
  --buffering_stop_stack $WM_GW_BUFFERING_STOP_STACK
                        Deprecated argument (it will be dropped from version
                        2.x onwards) please use --buffering_action instead.
                        (default: None)
```

</details>